### PR TITLE
feat(ledger): implement append-only ledger with multisig

### DIFF
--- a/apps/admin-web/src/App.tsx
+++ b/apps/admin-web/src/App.tsx
@@ -21,7 +21,7 @@ export default function App() {
       amount: 1,
       asset: 'QZD',
       to_account: account.id,
-      memo: 'System boot',
+      memo: 'system-start',
     });
     return ledger.getHistory();
   }, []);
@@ -31,7 +31,7 @@ export default function App() {
       <h1>Admin Console</h1>
       <ul>
         {entries.map((entry) => (
-          <li key={entry.tx_hash}>{`${entry.type} ${entry.amount} ${entry.asset}`}</li>
+          <li key={entry.tx_hash}>{`${entry.type} ${entry.amount} ${entry.asset} ${entry.memo ?? ''}`}</li>
         ))}
       </ul>
     </main>

--- a/apps/admin-web/src/App.tsx
+++ b/apps/admin-web/src/App.tsx
@@ -1,11 +1,29 @@
 import { useMemo } from 'react';
-import { createLedger, createSigner } from '@qzd/sdk';
+import { createLedger } from '@qzd/sdk';
+import type { LedgerConfig } from '@qzd/sdk';
+
+const ledgerConfig = {
+  issuanceThreshold: 1,
+  issuanceValidators: [
+    {
+      id: 'validator-1',
+      publicKey: '00'.repeat(66),
+    },
+  ],
+} satisfies LedgerConfig;
 
 export default function App() {
   const entries = useMemo(() => {
-    const signer = createSigner();
-    const ledger = createLedger<{ event: string }>();
-    return [ledger.append({ event: 'system-start' }, signer)];
+    const ledger = createLedger(ledgerConfig);
+    const account = ledger.openAccount({ alias: 'system', kyc_level: 'BASIC', public_key: 'system-key' });
+    ledger.postEntry({
+      type: 'ADJUST',
+      amount: 1,
+      asset: 'QZD',
+      to_account: account.id,
+      memo: 'System boot',
+    });
+    return ledger.getHistory();
   }, []);
 
   return (
@@ -13,7 +31,7 @@ export default function App() {
       <h1>Admin Console</h1>
       <ul>
         {entries.map((entry) => (
-          <li key={entry.hash}>{entry.payload.event}</li>
+          <li key={entry.tx_hash}>{`${entry.type} ${entry.amount} ${entry.asset}`}</li>
         ))}
       </ul>
     </main>

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
+    "fast-check": "^3.15.1",
     "typescript": "^5.3.3",
     "vitest": "^1.3.1"
   }

--- a/packages/ledger/src/index.spec.ts
+++ b/packages/ledger/src/index.spec.ts
@@ -1,14 +1,291 @@
 import { describe, expect, it } from 'vitest';
-import { AppendOnlyLedger, createSigner } from './index.js';
+import fc from 'fast-check';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { secp256k1 } from '@noble/curves/secp256k1';
+
+import {
+  AppendOnlyLedger,
+  type LedgerSignature,
+  type LedgerValidator,
+  type PostEntryInput,
+  validateMultisig,
+} from './index.js';
+
+const validatorPrivKeys = [
+  '4b8c5bd2b1c78e51a384643b4c8973d5ac25e83e5a69e9e9240a0f3a3e981f01',
+  '7f1ceab9da39979f68fb82ca5c22c02995ee50f74f072fe97c1a1c9bf9efcc02',
+  '5a6f06ed4af3ad7f26d2a7f85407a820b2ce52402ac2c2a3841216295dac8603',
+];
+
+const validators: LedgerValidator[] = validatorPrivKeys.map((hex, index) => ({
+  id: `validator-${index + 1}`,
+  publicKey: bytesToHex(secp256k1.getPublicKey(hexToBytes(hex), true)),
+}));
+
+function signCanonical(canonical: string, privHex: string): string {
+  const digest = sha256(new TextEncoder().encode(canonical));
+  return bytesToHex(secp256k1.sign(digest, hexToBytes(privHex)).toCompactRawBytes());
+}
+
+function canonicalString(input: PostEntryInput): string {
+  const payload = {
+    type: input.type,
+    amount: input.amount,
+    asset: input.asset,
+    from_account: input.from_account ?? null,
+    to_account: input.to_account ?? null,
+    memo: input.memo ?? null,
+    meta: input.meta ?? {},
+    ts: input.ts ? new Date(input.ts).toISOString() : undefined,
+  };
+
+  return JSON.stringify(canonicalize(payload));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).filter(([, v]) => v !== undefined);
+    entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of entries) {
+      result[key] = canonicalize(val);
+    }
+    return result;
+  }
+  return value;
+}
+
+function createLedger(threshold = 2) {
+  return new AppendOnlyLedger({ issuanceValidators: validators, issuanceThreshold: threshold });
+}
 
 describe('AppendOnlyLedger', () => {
-  it('appends signed entries that verify with public key', () => {
-    const ledger = new AppendOnlyLedger<{ amount: number }>();
-    const signer = createSigner();
+  it('issues funds with valid multisig and updates balance', () => {
+    const ledger = createLedger();
+    const recipient = ledger.openAccount({
+      alias: 'alice',
+      kyc_level: 'FULL',
+      public_key: 'alice-key',
+    });
 
-    const entry = ledger.append({ amount: 100 }, signer);
+    const entryInput: PostEntryInput = {
+      type: 'ISSUE',
+      amount: 1_000,
+      asset: 'QZD',
+      to_account: recipient.id,
+      sigs: [],
+    };
 
-    expect(entry.index).toBe(0);
-    expect(ledger.verify(entry, signer.publicKey)).toBe(true);
+    const canonical = canonicalString(entryInput);
+    entryInput.sigs = validatorPrivKeys.slice(0, 2).map((privHex, index) => ({
+      validatorId: validators[index].id,
+      signature: signCanonical(canonical, privHex),
+    }));
+
+    const entry = ledger.postEntry(entryInput);
+    expect(entry.tx_hash).toMatch(/^[0-9a-f]+$/);
+    expect(ledger.getAccountBalance(recipient.id, 'QZD')).toBe(1_000);
+  });
+
+  it('rejects issuance when signatures are invalid', () => {
+    const ledger = createLedger();
+    const recipient = ledger.openAccount({
+      alias: 'bob',
+      kyc_level: 'FULL',
+      public_key: 'bob-key',
+    });
+
+    const entryInput: PostEntryInput = {
+      type: 'ISSUE',
+      amount: 500,
+      asset: 'QZD',
+      to_account: recipient.id,
+      sigs: [
+        {
+          validatorId: validators[0].id,
+          signature: '00'.repeat(64),
+        },
+      ],
+    };
+
+    expect(() => ledger.postEntry(entryInput)).toThrowError('Invalid issuance signatures');
+  });
+
+  it('transfers funds between accounts', () => {
+    const ledger = createLedger();
+    const alice = ledger.openAccount({ alias: 'alice', kyc_level: 'FULL', public_key: 'alice-key' });
+    const bob = ledger.openAccount({ alias: 'bob', kyc_level: 'FULL', public_key: 'bob-key' });
+
+    const issueInput: PostEntryInput = {
+      type: 'ISSUE',
+      amount: 1_500,
+      asset: 'QZD',
+      to_account: alice.id,
+      sigs: [],
+    };
+    const issueCanonical = canonicalString(issueInput);
+    issueInput.sigs = validatorPrivKeys.slice(0, 2).map((privHex, index) => ({
+      validatorId: validators[index].id,
+      signature: signCanonical(issueCanonical, privHex),
+    }));
+    ledger.postEntry(issueInput);
+
+    ledger.postEntry({
+      type: 'TRANSFER',
+      amount: 700,
+      asset: 'QZD',
+      from_account: alice.id,
+      to_account: bob.id,
+    });
+
+    expect(ledger.getAccountBalance(alice.id, 'QZD')).toBe(800);
+    expect(ledger.getAccountBalance(bob.id, 'QZD')).toBe(700);
+  });
+
+  it('redeems funds and reduces balance', () => {
+    const ledger = createLedger();
+    const alice = ledger.openAccount({ alias: 'alice', kyc_level: 'FULL', public_key: 'alice-key' });
+
+    const issueInput: PostEntryInput = {
+      type: 'ISSUE',
+      amount: 1_000,
+      asset: 'QZD',
+      to_account: alice.id,
+      sigs: [],
+    };
+    const canonical = canonicalString(issueInput);
+    issueInput.sigs = validatorPrivKeys.slice(0, 2).map((privHex, index) => ({
+      validatorId: validators[index].id,
+      signature: signCanonical(canonical, privHex),
+    }));
+    ledger.postEntry(issueInput);
+
+    ledger.postEntry({
+      type: 'REDEEM',
+      amount: 400,
+      asset: 'QZD',
+      from_account: alice.id,
+    });
+
+    expect(ledger.getAccountBalance(alice.id, 'QZD')).toBe(600);
+  });
+
+  it('blocks transactions for frozen accounts', () => {
+    const ledger = createLedger();
+    const frozen = ledger.openAccount({
+      alias: 'frozen',
+      kyc_level: 'FULL',
+      public_key: 'frozen-key',
+      status: 'FROZEN',
+    });
+
+    const entryInput: PostEntryInput = {
+      type: 'ISSUE',
+      amount: 100,
+      asset: 'QZD',
+      to_account: frozen.id,
+      sigs: [],
+    };
+    const canonical = canonicalString(entryInput);
+    entryInput.sigs = validatorPrivKeys.slice(0, 2).map((privHex, index) => ({
+      validatorId: validators[index].id,
+      signature: signCanonical(canonical, privHex),
+    }));
+
+    expect(() => ledger.postEntry(entryInput)).toThrowError(/not active/);
+  });
+
+  it('validates multisig helper function', () => {
+    const payload: PostEntryInput = {
+      type: 'ISSUE',
+      amount: 100,
+      asset: 'QZD',
+      to_account: '1',
+    };
+    const canonical = canonicalString(payload);
+    const signatures: LedgerSignature[] = validatorPrivKeys.slice(0, 2).map((privHex, index) => ({
+      validatorId: validators[index].id,
+      signature: signCanonical(canonical, privHex),
+    }));
+
+    expect(
+      validateMultisig({
+        canonical,
+        signatures,
+        validators,
+        threshold: 2,
+      }),
+    ).toBe(true);
+
+    expect(
+      validateMultisig({
+        canonical,
+        signatures,
+        validators,
+        threshold: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it('preserves conservation of value for transfers', () => {
+    const ledger = createLedger();
+    const accounts = Array.from({ length: 3 }, (_, i) =>
+      ledger.openAccount({ alias: `acct-${i}`, kyc_level: 'FULL', public_key: `key-${i}` }),
+    );
+
+    const issueInput: PostEntryInput = {
+      type: 'ISSUE',
+      amount: 3_000,
+      asset: 'QZD',
+      to_account: accounts[0].id,
+      sigs: [],
+    };
+    const canonical = canonicalString(issueInput);
+    issueInput.sigs = validatorPrivKeys.slice(0, 2).map((privHex, index) => ({
+      validatorId: validators[index].id,
+      signature: signCanonical(canonical, privHex),
+    }));
+    ledger.postEntry(issueInput);
+
+    const transferArb = fc.record({
+      from: fc.integer({ min: 0, max: accounts.length - 1 }),
+      to: fc.integer({ min: 0, max: accounts.length - 1 }),
+      amount: fc.integer({ min: 1, max: 500 }),
+    });
+
+    fc.assert(
+      fc.property(transferArb, ({ from, to, amount }) => {
+        fc.pre(from !== to);
+        const fromAccount = accounts[from];
+        const toAccount = accounts[to];
+        const currentBalance = ledger.getAccountBalance(fromAccount.id, 'QZD');
+        fc.pre(currentBalance >= amount);
+
+        ledger.postEntry({
+          type: 'TRANSFER',
+          amount,
+          asset: 'QZD',
+          from_account: fromAccount.id,
+          to_account: toAccount.id,
+        });
+
+        const entries = ledger.getHistory();
+        const totalIssued = entries
+          .filter((entry) => entry.type === 'ISSUE' && entry.asset === 'QZD')
+          .reduce((sum, entry) => sum + entry.amount, 0);
+        const totalRedeemed = entries
+          .filter((entry) => entry.type === 'REDEEM' && entry.asset === 'QZD')
+          .reduce((sum, entry) => sum + entry.amount, 0);
+        const balances = accounts.map((acct) => ledger.getAccountBalance(acct.id, 'QZD'));
+        const net = balances.reduce((sum, bal) => sum + bal, 0);
+
+        expect(net).toBe(totalIssued - totalRedeemed);
+      }),
+      { numRuns: 25 },
+    );
   });
 });

--- a/packages/ledger/src/index.ts
+++ b/packages/ledger/src/index.ts
@@ -131,7 +131,7 @@ export class AppendOnlyLedger {
       }
     }
 
-    const canonical = buildCanonicalPayload(input);
+    const canonical = canonicalizeEntryPayload(input);
 
     if (input.type === 'ISSUE') {
       const isValid = validateMultisig({
@@ -259,7 +259,7 @@ export function validateMultisig(input: MultisigValidationInput): boolean {
   return verified >= input.threshold;
 }
 
-function buildCanonicalPayload(input: PostEntryInput): string {
+export function canonicalizeEntryPayload(input: PostEntryInput): string {
   const payload: CanonicalPayload = {
     type: input.type,
     amount: input.amount,

--- a/packages/ledger/src/index.ts
+++ b/packages/ledger/src/index.ts
@@ -1,57 +1,335 @@
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { secp256k1 } from '@noble/curves/secp256k1';
-import type { HealthResponse } from '@qzd/shared';
 
-export type LedgerEntry<T = unknown> = {
-  index: number;
-  payload: T;
-  previousHash: string | null;
-  hash: string;
-  signature: string;
-};
+export type AccountStatus = 'ACTIVE' | 'FROZEN';
+export type KycLevel = 'BASIC' | 'FULL';
+export type LedgerEntryType = 'ISSUE' | 'TRANSFER' | 'REDEEM' | 'ADJUST';
 
-export interface LedgerSigner {
-  privateKey: Uint8Array;
-  publicKey: Uint8Array;
+export interface Account {
+  id: string;
+  alias: string;
+  kyc_level: KycLevel;
+  status: AccountStatus;
+  public_key: string;
 }
 
-export class AppendOnlyLedger<T = unknown> {
-  private readonly entries: LedgerEntry<T>[] = [];
+export interface LedgerSignature {
+  validatorId: string;
+  signature: string;
+}
 
-  append(payload: T, signer: LedgerSigner): LedgerEntry<T> {
-    const previousHash = this.entries.at(-1)?.hash ?? null;
-    const index = this.entries.length;
-    const message = this.encodeMessage(index, payload, previousHash);
-    const digest = sha256(message);
-    const signature = bytesToHex(secp256k1.sign(digest, signer.privateKey).toCompactRawBytes());
-    const hash = bytesToHex(digest);
+export interface LedgerEntryMeta {
+  [key: string]: unknown;
+}
 
-    const entry: LedgerEntry<T> = { index, payload, previousHash, hash, signature };
+export interface LedgerEntry {
+  id: number;
+  ts: string;
+  type: LedgerEntryType;
+  amount: number;
+  asset: string;
+  from_account: string | null;
+  to_account: string | null;
+  memo: string | null;
+  tx_hash: string;
+  sigs: LedgerSignature[];
+  meta: LedgerEntryMeta;
+}
+
+export interface LedgerValidator {
+  id: string;
+  publicKey: string;
+}
+
+export interface LedgerConfig {
+  issuanceValidators: LedgerValidator[];
+  issuanceThreshold?: number;
+}
+
+export interface AccountInput {
+  alias: string;
+  kyc_level: KycLevel;
+  public_key: string;
+  status?: AccountStatus;
+}
+
+export interface PostEntryInput {
+  type: LedgerEntryType;
+  amount: number;
+  asset: string;
+  from_account?: string | null;
+  to_account?: string | null;
+  memo?: string | null;
+  sigs?: LedgerSignature[];
+  meta?: LedgerEntryMeta;
+  ts?: string | Date;
+}
+
+export type MultisigValidationInput = {
+  canonical: string;
+  signatures: LedgerSignature[];
+  validators: LedgerValidator[];
+  threshold: number;
+};
+
+export type CanonicalPayload = Record<string, unknown>;
+
+export class AppendOnlyLedger {
+  private readonly accounts = new Map<string, Account>();
+  private readonly accountsByAlias = new Map<string, Account>();
+  private readonly entries: LedgerEntry[] = [];
+  private readonly issuanceValidators: LedgerValidator[];
+  private readonly issuanceThreshold: number;
+  private accountSeq = 0;
+
+  constructor(config: LedgerConfig) {
+    this.issuanceValidators = config.issuanceValidators;
+    const threshold = config.issuanceThreshold ?? 2;
+    if (threshold < 1 || threshold > this.issuanceValidators.length) {
+      throw new Error('Invalid issuance threshold configuration');
+    }
+    this.issuanceThreshold = threshold;
+  }
+
+  openAccount(input: AccountInput): Account {
+    if (this.accountsByAlias.has(input.alias)) {
+      throw new Error('Account alias already exists');
+    }
+    const id = `${++this.accountSeq}`;
+    const account: Account = {
+      id,
+      alias: input.alias,
+      kyc_level: input.kyc_level,
+      status: input.status ?? 'ACTIVE',
+      public_key: input.public_key,
+    };
+    this.accounts.set(id, account);
+    this.accountsByAlias.set(account.alias, account);
+    return account;
+  }
+
+  getAccount(id: string): Account | undefined {
+    return this.accounts.get(id);
+  }
+
+  postEntry(input: PostEntryInput): LedgerEntry {
+    validateEntryInput(input);
+
+    const fromAccount = input.from_account ? this.assertActiveAccount(input.from_account, 'from_account') : null;
+    const toAccount = input.to_account ? this.assertActiveAccount(input.to_account, 'to_account') : null;
+
+    const now = input.ts ? new Date(input.ts).toISOString() : new Date().toISOString();
+
+    if (input.type === 'TRANSFER' || input.type === 'REDEEM') {
+      if (!fromAccount) {
+        throw new Error('from_account is required');
+      }
+      const balance = this.getAccountBalance(fromAccount.id, input.asset);
+      if (balance < input.amount) {
+        throw new Error('Insufficient balance');
+      }
+    }
+
+    const canonical = buildCanonicalPayload(input);
+
+    if (input.type === 'ISSUE') {
+      const isValid = validateMultisig({
+        canonical,
+        signatures: input.sigs ?? [],
+        validators: this.issuanceValidators,
+        threshold: this.issuanceThreshold,
+      });
+      if (!isValid) {
+        throw new Error('Invalid issuance signatures');
+      }
+    }
+
+    if (input.type === 'REDEEM' && !fromAccount) {
+      throw new Error('Redeem requires from_account');
+    }
+
+    const txHash = bytesToHex(sha256(new TextEncoder().encode(canonical)));
+
+    const entry: LedgerEntry = {
+      id: this.entries.length + 1,
+      ts: now,
+      type: input.type,
+      amount: input.amount,
+      asset: input.asset,
+      from_account: fromAccount?.id ?? null,
+      to_account: toAccount?.id ?? null,
+      memo: input.memo ?? null,
+      tx_hash: txHash,
+      sigs: input.sigs ?? [],
+      meta: input.meta ?? {},
+    };
+
     this.entries.push(entry);
     return entry;
   }
 
-  verify(entry: LedgerEntry<T>, publicKey: Uint8Array): boolean {
-    const message = this.encodeMessage(entry.index, entry.payload, entry.previousHash);
-    const digest = sha256(message);
-    return secp256k1.verify(hexToBytes(entry.signature), digest, publicKey);
+  getAccountBalance(accountId: string, asset: string): number {
+    let balance = 0;
+    for (const entry of this.entries) {
+      if (entry.asset !== asset) continue;
+      switch (entry.type) {
+        case 'ISSUE':
+          if (entry.to_account === accountId) {
+            balance += entry.amount;
+          }
+          break;
+        case 'TRANSFER':
+          if (entry.from_account === accountId) {
+            balance -= entry.amount;
+          }
+          if (entry.to_account === accountId) {
+            balance += entry.amount;
+          }
+          break;
+        case 'REDEEM':
+          if (entry.from_account === accountId) {
+            balance -= entry.amount;
+          }
+          break;
+        case 'ADJUST':
+          if (entry.from_account === accountId) {
+            balance -= entry.amount;
+          }
+          if (entry.to_account === accountId) {
+            balance += entry.amount;
+          }
+          break;
+      }
+    }
+    return balance;
   }
 
-  getAll() {
-    return [...this.entries];
+  getHistory(accountId?: string): LedgerEntry[] {
+    if (!accountId) {
+      return [...this.entries];
+    }
+    return this.entries.filter(
+      (entry) => entry.from_account === accountId || entry.to_account === accountId,
+    );
   }
 
-  private encodeMessage(index: number, payload: T, previousHash: string | null) {
-    const text = JSON.stringify({ index, payload, previousHash });
-    return new TextEncoder().encode(text);
+  private assertActiveAccount(accountId: string, field: 'from_account' | 'to_account'): Account {
+    const account = this.accounts.get(accountId);
+    if (!account) {
+      throw new Error(`Unknown ${field}`);
+    }
+    if (account.status !== 'ACTIVE') {
+      throw new Error(`Account ${account.id} is not active`);
+    }
+    return account;
   }
 }
 
-export function createSigner(): LedgerSigner {
-  const privateKey = secp256k1.utils.randomPrivateKey();
-  const publicKey = secp256k1.getPublicKey(privateKey);
-  return { privateKey, publicKey };
+export function validateMultisig(input: MultisigValidationInput): boolean {
+  if (input.threshold < 1 || input.threshold > input.validators.length) {
+    return false;
+  }
+  if (input.signatures.length < input.threshold) {
+    return false;
+  }
+
+  const digest = sha256(new TextEncoder().encode(input.canonical));
+  const validatorMap = new Map(input.validators.map((v) => [v.id, v.publicKey]));
+  const seen = new Set<string>();
+  let verified = 0;
+
+  for (const sig of input.signatures) {
+    if (seen.has(sig.validatorId)) {
+      continue;
+    }
+    const validatorKey = validatorMap.get(sig.validatorId);
+    if (!validatorKey) {
+      continue;
+    }
+    const signatureBytes = hexToBytes(sig.signature);
+    if (secp256k1.verify(signatureBytes, digest, hexToBytes(validatorKey))) {
+      seen.add(sig.validatorId);
+      verified += 1;
+      if (verified >= input.threshold) {
+        return true;
+      }
+    }
+  }
+  return verified >= input.threshold;
 }
 
-export type { HealthResponse };
+function buildCanonicalPayload(input: PostEntryInput): string {
+  const payload: CanonicalPayload = {
+    type: input.type,
+    amount: input.amount,
+    asset: input.asset,
+    from_account: input.from_account ?? null,
+    to_account: input.to_account ?? null,
+    memo: input.memo ?? null,
+    meta: input.meta ?? {},
+    ts: input.ts ? new Date(input.ts).toISOString() : undefined,
+  };
+  return canonicalJSONString(payload);
+}
+
+function validateEntryInput(input: PostEntryInput) {
+  if (!Number.isInteger(input.amount) || input.amount <= 0) {
+    throw new Error('Amount must be a positive integer');
+  }
+  if (!input.asset) {
+    throw new Error('Asset is required');
+  }
+  switch (input.type) {
+    case 'ISSUE':
+      if (!input.to_account) {
+        throw new Error('Issue requires to_account');
+      }
+      break;
+    case 'TRANSFER':
+      if (!input.from_account || !input.to_account) {
+        throw new Error('Transfer requires from_account and to_account');
+      }
+      if (input.from_account === input.to_account) {
+        throw new Error('Transfer accounts must differ');
+      }
+      break;
+    case 'REDEEM':
+      if (!input.from_account) {
+        throw new Error('Redeem requires from_account');
+      }
+      if (input.to_account) {
+        throw new Error('Redeem cannot specify to_account');
+      }
+      break;
+    case 'ADJUST':
+      if (!input.from_account && !input.to_account) {
+        throw new Error('Adjust requires at least one account');
+      }
+      break;
+    default:
+      throw new Error('Unsupported entry type');
+  }
+}
+
+function canonicalJSONString(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).filter(([, v]) => v !== undefined);
+    entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of entries) {
+      result[key] = canonicalize(val);
+    }
+    return result;
+  }
+  return value;
+}
+
+export type { LedgerEntry as Entry, Account as LedgerAccount };

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -22,6 +22,8 @@
     "@qzd/shared": "workspace:*"
   },
   "devDependencies": {
+    "@noble/curves": "^1.6.0",
+    "@noble/hashes": "^1.6.0",
     "@types/node": "^20.11.0",
     "typescript": "^5.3.3",
     "vitest": "^1.3.1"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -12,8 +12,9 @@
   },
   "files": ["dist"],
   "scripts": {
+    "pretest": "pnpm --filter @qzd/shared build && pnpm --filter @qzd/ledger build",
     "build": "tsup src/index.ts --dts --format esm --out-dir dist --clean",
-    "test": "vitest run",
+    "test": "pnpm run pretest && vitest run",
     "lint": "eslint \"src/**/*.ts\"",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/sdk/src/index.spec.ts
+++ b/packages/sdk/src/index.spec.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { ApiClient, createLedger, createSigner } from './index.js';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { secp256k1 } from '@noble/curves/secp256k1';
+
+import { ApiClient, createLedger } from './index.js';
+import type { LedgerConfig, LedgerSignature } from '@qzd/ledger';
 
 describe('ApiClient', () => {
   it('parses health response', async () => {
@@ -17,12 +22,65 @@ describe('ApiClient', () => {
 });
 
 describe('createLedger', () => {
-  it('creates a ledger capable of signing entries', () => {
-    const ledger = createLedger<{ memo: string }>();
-    const signer = createSigner();
-    const entry = ledger.append({ memo: 'hello' }, signer);
+  it('creates a ledger with configurable validators', () => {
+    const validatorPrivKeys = [
+      '4b8c5bd2b1c78e51a384643b4c8973d5ac25e83e5a69e9e9240a0f3a3e981f01',
+      '7f1ceab9da39979f68fb82ca5c22c02995ee50f74f072fe97c1a1c9bf9efcc02',
+      '5a6f06ed4af3ad7f26d2a7f85407a820b2ce52402ac2c2a3841216295dac8603',
+    ];
 
-    expect(entry.index).toBe(0);
-    expect(ledger.verify(entry, signer.publicKey)).toBe(true);
+    const config: LedgerConfig = {
+      issuanceThreshold: 2,
+      issuanceValidators: validatorPrivKeys.map((privHex, idx) => ({
+        id: `validator-${idx + 1}`,
+        publicKey: bytesToHex(secp256k1.getPublicKey(hexToBytes(privHex), true)),
+      })),
+    };
+
+    const ledger = createLedger(config);
+    const account = ledger.openAccount({ alias: 'alice', kyc_level: 'FULL', public_key: 'alice-key' });
+
+    const payload = {
+      type: 'ISSUE' as const,
+      amount: 100,
+      asset: 'QZD',
+      to_account: account.id,
+      sigs: [] as LedgerSignature[],
+    };
+
+    const canonical = canonicalString(payload);
+    payload.sigs = validatorPrivKeys.slice(0, 2).map((privHex, index) => ({
+      validatorId: config.issuanceValidators[index].id,
+      signature: signCanonical(canonical, privHex),
+    }));
+
+    const entry = ledger.postEntry(payload);
+    expect(entry.type).toBe('ISSUE');
+    expect(ledger.getAccountBalance(account.id, 'QZD')).toBe(100);
   });
 });
+
+function signCanonical(canonical: string, privHex: string): string {
+  const digest = sha256(new TextEncoder().encode(canonical));
+  return bytesToHex(secp256k1.sign(digest, hexToBytes(privHex)).toCompactRawBytes());
+}
+
+function canonicalString(input: { [key: string]: unknown }): string {
+  return JSON.stringify(canonicalize(input));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).filter(([, v]) => v !== undefined);
+    entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of entries) {
+      result[key] = canonicalize(val);
+    }
+    return result;
+  }
+  return value;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,7 +1,7 @@
 import type { HealthResponse } from '@qzd/shared';
 import { healthResponseSchema } from '@qzd/shared';
-import type { AppendOnlyLedger, LedgerEntry } from '@qzd/ledger';
-import { AppendOnlyLedger as Ledger, createSigner } from '@qzd/ledger';
+import type { LedgerEntry, LedgerConfig } from '@qzd/ledger';
+import { AppendOnlyLedger as Ledger, validateMultisig } from '@qzd/ledger';
 export interface ApiClientOptions {
   baseUrl: string;
 }
@@ -16,9 +16,9 @@ export class ApiClient {
   }
 }
 
-export function createLedger<T>(): AppendOnlyLedger<T> {
-  return new Ledger<T>();
+export function createLedger(config: LedgerConfig): Ledger {
+  return new Ledger(config);
 }
 
-export { createSigner };
-export type { LedgerEntry };
+export { validateMultisig };
+export type { LedgerEntry, LedgerConfig };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@types/node':
         specifier: ^20.11.0
         version: 20.19.17
+      fast-check:
+        specifier: ^3.15.1
+        version: 3.23.2
       typescript:
         specifier: ^5.3.3
         version: 5.9.2
@@ -190,6 +193,12 @@ importers:
         specifier: workspace:*
         version: link:../shared
     devDependencies:
+      '@noble/curves':
+        specifier: ^1.6.0
+        version: 1.9.7
+      '@noble/hashes':
+        specifier: ^1.6.0
+        version: 1.8.0
       '@types/node':
         specifier: ^20.11.0
         version: 20.19.17
@@ -1156,7 +1165,6 @@ packages:
     engines: {node: ^14.21.3 || >=16}
     dependencies:
       '@noble/hashes': 1.8.0
-    dev: false
 
   /@noble/hashes@1.8.0:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -2575,6 +2583,13 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      pure-rand: 6.1.0
+    dev: true
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
@@ -3709,6 +3724,10 @@ packages:
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+    dev: true
+
+  /pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
     dev: true
 
   /qs@6.13.0:


### PR DESCRIPTION
## Summary
- replace the simple ledger with an append-only ledger that tracks accounts, enforces multisig issuance, and derives balances deterministically
- cover issuance, transfer, redemption, frozen accounts, and conservation invariants with new Vitest and fast-check suites
- update the SDK and admin demo to work with the new ledger API and expose multisig-aware helpers

## Testing
- `pnpm --filter @qzd/ledger test`
- `pnpm --filter @qzd/sdk typecheck`
- `pnpm --filter @qzd/admin-web typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68d493a1e0c8833099cb8375d94a4075