### PR TITLE
Add KYC account updates and transfer guard

### DIFF
--- a/apps/api/src/impl/account-policy.middleware.spec.ts
+++ b/apps/api/src/impl/account-policy.middleware.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { Account, MonetaryAmount } from '@qzd/sdk-api/server';
+import {
+  ACCOUNT_FROZEN_ERROR,
+  AccountTransferGuard,
+  LIMIT_EXCEEDED_ERROR,
+  PolicyViolationException,
+} from './account-policy.middleware.js';
+
+const baseAccount: Account = {
+  id: 'acc_001',
+  ownerId: 'usr_001',
+  ownerName: 'Test User',
+  status: 'ACTIVE',
+  kycLevel: 'BASIC',
+  createdAt: '2024-05-01T00:00:00.000Z',
+  metadata: {},
+};
+
+const amount = (value: string): MonetaryAmount => ({
+  currency: 'QZD',
+  value,
+});
+
+describe('AccountTransferGuard', () => {
+  it('enforces BASIC daily transfer limits', () => {
+    const guard = new AccountTransferGuard(() => new Date('2024-05-05T12:00:00Z'));
+    guard.enforce({ account: baseAccount, amount: amount('3000.00') });
+
+    let thrown: unknown;
+    try {
+      guard.enforce({ account: baseAccount, amount: amount('2500.00') });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(PolicyViolationException);
+    const violation = thrown as PolicyViolationException;
+    expect(violation.code).toBe(LIMIT_EXCEEDED_ERROR);
+    expect(violation.getResponse()).toMatchObject({ code: LIMIT_EXCEEDED_ERROR });
+  });
+
+  it('blocks frozen accounts before evaluating limits', () => {
+    const guard = new AccountTransferGuard(() => new Date('2024-05-05T12:00:00Z'));
+    const frozenAccount: Account = { ...baseAccount, status: 'FROZEN' };
+
+    let thrown: unknown;
+    try {
+      guard.enforce({ account: frozenAccount, amount: amount('10.00') });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(PolicyViolationException);
+    const violation = thrown as PolicyViolationException;
+    expect(violation.code).toBe(ACCOUNT_FROZEN_ERROR);
+    expect(violation.getResponse()).toMatchObject({ code: ACCOUNT_FROZEN_ERROR });
+    expect(guard.getUsage(frozenAccount.id, 'QZD')).toBe(0);
+  });
+});

--- a/apps/api/src/impl/account-policy.middleware.ts
+++ b/apps/api/src/impl/account-policy.middleware.ts
@@ -1,0 +1,102 @@
+import { ForbiddenException } from '@nestjs/common';
+import type { Account, MonetaryAmount } from '@qzd/sdk-api/server';
+
+type AccountKycLevel = Account['kycLevel'];
+
+export const ACCOUNT_FROZEN_ERROR = 'ACCOUNT_FROZEN' as const;
+export const LIMIT_EXCEEDED_ERROR = 'LIMIT_EXCEEDED' as const;
+
+export type PolicyErrorCode =
+  | typeof ACCOUNT_FROZEN_ERROR
+  | typeof LIMIT_EXCEEDED_ERROR;
+
+export interface TransferContext {
+  account: Account;
+  amount: MonetaryAmount;
+}
+
+type UsageKey = string;
+
+type Clock = () => Date;
+
+const DAILY_LIMITS_MINOR_UNITS: Record<AccountKycLevel, number> = {
+  BASIC: 5000_00,
+  FULL: 50000_00,
+};
+
+export class PolicyViolationException extends ForbiddenException {
+  constructor(public readonly code: PolicyErrorCode, message: string) {
+    super({ code, message });
+  }
+}
+
+export class AccountTransferGuard {
+  private readonly usage = new Map<UsageKey, number>();
+
+  constructor(private readonly clock: Clock = () => new Date()) {}
+
+  enforce({ account, amount }: TransferContext): void {
+    ensureAccountActive(account);
+    const now = this.clock();
+    const key = this.buildUsageKey(account.id, amount.currency, now);
+    const alreadySpent = this.usage.get(key) ?? 0;
+    const requested = toMinorUnits(amount.value);
+
+    ensureWithinDailyLimit(account, requested, alreadySpent);
+
+    this.usage.set(key, alreadySpent + requested);
+  }
+
+  getUsage(accountId: string, currency: string, at: Date = this.clock()): number {
+    return this.usage.get(this.buildUsageKey(accountId, currency, at)) ?? 0;
+  }
+
+  private buildUsageKey(accountId: string, currency: string, at: Date): UsageKey {
+    const day = at.toISOString().slice(0, 10);
+    return `${accountId}:${currency}:${day}`;
+  }
+}
+
+export function ensureAccountActive(account: Pick<Account, 'id' | 'status'>): void {
+  if (account.status !== 'ACTIVE') {
+    throw new PolicyViolationException(
+      ACCOUNT_FROZEN_ERROR,
+      `Account ${account.id} is frozen and cannot initiate transfers.`,
+    );
+  }
+}
+
+export function ensureWithinDailyLimit(
+  account: Pick<Account, 'id' | 'kycLevel'>,
+  requestedMinorUnits: number,
+  alreadySpentMinorUnits: number,
+): void {
+  const limit = DAILY_LIMITS_MINOR_UNITS[account.kycLevel];
+  if (alreadySpentMinorUnits + requestedMinorUnits > limit) {
+    const limitFormatted = formatMinorUnits(limit);
+    throw new PolicyViolationException(
+      LIMIT_EXCEEDED_ERROR,
+      `Daily transfer limit of ${limitFormatted} exceeded for account ${account.id}.`,
+    );
+  }
+}
+
+function toMinorUnits(value: string): number {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) {
+    throw new TypeError(`Invalid monetary amount: ${value}`);
+  }
+  return Math.round(parsed * 100);
+}
+
+function formatMinorUnits(minorUnits: number): string {
+  const major = minorUnits / 100;
+  return `Q${major.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+export function applyAccountGuards(guard: AccountTransferGuard, context: TransferContext): void {
+  guard.enforce(context);
+}

--- a/apps/api/src/impl/accounts.api.ts
+++ b/apps/api/src/impl/accounts.api.ts
@@ -8,6 +8,7 @@ import type {
   Balance,
   CreateAccountRequest,
   ListAccountTransactions200Response,
+  UploadAccountKycRequest,
 } from '@qzd/sdk-api/server';
 
 @Injectable()
@@ -35,6 +36,13 @@ export class AccountsApiImpl extends AccountsApi {
     | ListAccountTransactions200Response
     | Promise<ListAccountTransactions200Response>
     | Observable<ListAccountTransactions200Response> {
+    throw new Error('Method not implemented.');
+  }
+
+  override uploadAccountKyc(
+    uploadAccountKycRequest: UploadAccountKycRequest,
+    request: Request,
+  ): Account | Promise<Account> | Observable<Account> {
     throw new Error('Method not implemented.');
   }
 }

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -81,7 +81,8 @@ paths:
                   ownerId: "usr_123456789"
                   id: "acc_987654321"
                   ownerName: "Alex Merchant"
-                  status: active
+                  status: ACTIVE
+                  kycLevel: BASIC
                   createdAt: "2024-05-01T12:30:00Z"
                 token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
         '400':
@@ -185,7 +186,8 @@ paths:
                 id: "acc_987654321"
                 ownerId: "usr_123456789"
                 ownerName: "Northbridge Holdings"
-                status: active
+                status: ACTIVE
+                kycLevel: BASIC
                 createdAt: "2024-05-01T12:30:00Z"
         '400':
           $ref: '#/components/responses/BadRequestError'
@@ -193,6 +195,49 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/ForbiddenError'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /accounts/kyc:
+    post:
+      tags:
+        - Accounts
+      operationId: uploadAccountKyc
+      summary: Submit KYC evidence for an existing account.
+      description: >-
+        Upload new metadata, documents, or questionnaire answers to advance an
+        account's KYC status. Approved submissions can upgrade the account to
+        FULL status, unlocking higher daily transfer limits.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UploadAccountKycRequest'
+            example:
+              accountId: "acc_987654321"
+              kycLevel: FULL
+              metadata:
+                documentType: "PASSPORT"
+                documentNumber: "123456789"
+      responses:
+        '200':
+          description: Account KYC metadata accepted and account updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
         '409':
           $ref: '#/components/responses/ConflictError'
         '429':
@@ -311,6 +356,11 @@ paths:
         - Transactions
       operationId: initiateTransfer
       summary: Move balances between accounts.
+      description: >-
+        Transfers are limited by the originating account's KYC tier. BASIC
+        accounts may send up to Q5,000 per day while FULL accounts may send up
+        to Q50,000 per day. Requests exceeding these thresholds will be
+        rejected with a LIMIT_EXCEEDED error.
       requestBody:
         required: true
         content:
@@ -597,7 +647,8 @@ paths:
                 validators:
                   - id: "val_001"
                     name: "QZD Northern Node"
-                    status: active
+                    status: ACTIVE
+                    kycLevel: FULL
                     endpoint: "https://validator1.qzd.example.com"
                   - id: "val_002"
                     name: "QZD Southern Node"
@@ -831,10 +882,21 @@ components:
           type: string
         status:
           type: string
+          description: >-
+            Current account state. Frozen accounts are blocked from initiating
+            transfers until reactivated.
           enum:
-            - active
-            - suspended
-            - closed
+            - ACTIVE
+            - FROZEN
+        kycLevel:
+          type: string
+          description: >-
+            Know Your Customer (KYC) tier that controls daily transfer limits.
+            BASIC accounts may move up to Q5,000 per day while FULL accounts may
+            transfer up to Q50,000 per day.
+          enum:
+            - BASIC
+            - FULL
         createdAt:
           type: string
           format: date-time
@@ -846,7 +908,27 @@ components:
         - id
         - ownerId
         - status
+        - kycLevel
         - createdAt
+    UploadAccountKycRequest:
+      type: object
+      properties:
+        accountId:
+          type: string
+        kycLevel:
+          type: string
+          enum:
+            - BASIC
+            - FULL
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+          description: Structured evidence payload such as document references.
+      required:
+        - accountId
+        - kycLevel
+        - metadata
     Balance:
       type: object
       properties:
@@ -908,6 +990,10 @@ components:
         - createdAt
     TransferRequest:
       type: object
+      description: >-
+        Transfer instructions count toward an account's daily movement limit.
+        BASIC accounts may submit no more than Q5,000 per 24-hour window while
+        FULL accounts may transfer up to Q50,000.
       properties:
         sourceAccountId:
           type: string
@@ -1063,6 +1149,17 @@ components:
       properties:
         code:
           type: string
+          enum:
+            - BAD_REQUEST
+            - UNAUTHORIZED
+            - FORBIDDEN
+            - NOT_FOUND
+            - CONFLICT
+            - TOO_MANY_REQUESTS
+            - INTERNAL_ERROR
+            - SERVICE_UNAVAILABLE
+            - LIMIT_EXCEEDED
+            - ACCOUNT_FROZEN
         message:
           type: string
         details:


### PR DESCRIPTION
## Summary
- extend the Account schema with KYC tier metadata, frozen status, and document the new /accounts/kyc submission workflow
- update generated OpenAPI types after documenting daily BASIC/FULL transfer limits and new LIMIT_EXCEEDED / ACCOUNT_FROZEN error codes
- add an account transfer guard middleware that enforces freeze and limit policies with unit coverage

## Testing
- pnpm --filter @qzd/api test

------
https://chatgpt.com/codex/tasks/task_e_68d6164d2f7083308b556b28408aa0df