### PR TITLE
Implement issuance request queue and admin tooling

### DIFF
--- a/apps/admin-web/package.json
+++ b/apps/admin-web/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@qzd/sdk": "workspace:*",
+    "@qzd/sdk-browser": "workspace:*",
     "@qzd/shared": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/admin-web/src/App.test.tsx
+++ b/apps/admin-web/src/App.test.tsx
@@ -1,10 +1,45 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import App from './App';
 
+vi.mock('@qzd/sdk-browser', () => {
+  class MockAdminApi {
+    listIssuanceRequests = vi.fn().mockResolvedValue({ items: [] });
+    signIssuanceRequest = vi.fn().mockResolvedValue({});
+    createIssuanceRequest = vi.fn().mockResolvedValue({});
+  }
+
+  class MockConfiguration {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    constructor() {}
+  }
+
+  return { AdminApi: MockAdminApi, Configuration: MockConfiguration };
+});
+
 describe('Admin App', () => {
-  it('lists system events', () => {
+  it('renders the issuance queue layout', () => {
     render(<App />);
-    expect(screen.getByText(/system-start/i)).toBeInTheDocument();
+
+    expect(screen.getByRole('heading', { level: 1, name: /issuance queue/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /connection/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: /create issuance request/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /validator actions/i })).toBeInTheDocument();
+  });
+
+  it('prefills connection defaults and validator identity', () => {
+    render(<App />);
+
+    expect(screen.getByPlaceholderText('http://localhost:3000')).toHaveValue('http://localhost:3000');
+    expect(screen.getByPlaceholderText('Paste bearer token')).toHaveValue('');
+    expect(screen.getByRole('combobox', { name: /validator identity/i })).toHaveDisplayValue('validator-1');
+  });
+
+  it('shows empty issuance queue message by default', () => {
+    render(<App />);
+
+    expect(screen.getAllByText(/no issuance requests available/i)[0]).toBeInTheDocument();
   });
 });

--- a/apps/admin-web/src/App.tsx
+++ b/apps/admin-web/src/App.tsx
@@ -1,39 +1,310 @@
-import { useMemo } from 'react';
-import { createLedger } from '@qzd/sdk';
-import type { LedgerConfig } from '@qzd/sdk';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { FormEvent } from 'react';
+import { AdminApi, Configuration, type IssuanceRequest } from '@qzd/sdk-browser';
 
-const ledgerConfig = {
-  issuanceThreshold: 1,
-  issuanceValidators: [
-    {
-      id: 'validator-1',
-      publicKey: '00'.repeat(66),
-    },
-  ],
-} satisfies LedgerConfig;
+const DEFAULT_API_BASE_URL = 'http://localhost:3000';
+const KNOWN_VALIDATORS = ['validator-1', 'validator-2', 'validator-3'] as const;
+
+type AsyncStatus = 'idle' | 'pending';
+
+type ValidatorId = (typeof KNOWN_VALIDATORS)[number];
+
+function sanitizeBaseUrl(value: string | undefined): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return DEFAULT_API_BASE_URL;
+  }
+  return trimmed.replace(/\/+$/, '');
+}
+
+function formatAmount(amount: IssuanceRequest['amount']): string {
+  return `${amount.value} ${amount.currency}`;
+}
+
+function formatProgress(request: IssuanceRequest): string {
+  return `${request.status} (${request.collected}/${request.required})`;
+}
 
 export default function App() {
-  const entries = useMemo(() => {
-    const ledger = createLedger(ledgerConfig);
-    const account = ledger.openAccount({ alias: 'system', kyc_level: 'BASIC', public_key: 'system-key' });
-    ledger.postEntry({
-      type: 'ADJUST',
-      amount: 1,
-      asset: 'QZD',
-      to_account: account.id,
-      memo: 'system-start',
-    });
-    return ledger.getHistory();
+  const configuredBaseUrl = sanitizeBaseUrl(import.meta.env.VITE_API_BASE_URL as string | undefined);
+  const [baseUrlInput, setBaseUrlInput] = useState(configuredBaseUrl);
+  const [baseUrl, setBaseUrl] = useState(configuredBaseUrl);
+  const [tokenInput, setTokenInput] = useState('');
+  const [token, setToken] = useState<string | null>(null);
+  const [selectedValidator, setSelectedValidator] = useState<ValidatorId>(KNOWN_VALIDATORS[0]);
+  const [requests, setRequests] = useState<IssuanceRequest[]>([]);
+  const [loading, setLoading] = useState<AsyncStatus>('idle');
+  const [signingId, setSigningId] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [accountIdInput, setAccountIdInput] = useState('');
+  const [amountInput, setAmountInput] = useState('100.00');
+  const [currencyInput, setCurrencyInput] = useState('QZD');
+  const [referenceInput, setReferenceInput] = useState('');
+  const [createStatus, setCreateStatus] = useState<AsyncStatus>('idle');
+
+  const configuration = useMemo(
+    () =>
+      new Configuration({
+        basePath: baseUrl,
+        accessToken: token ? async () => token : undefined,
+      }),
+    [baseUrl, token],
+  );
+
+  const adminApi = useMemo(() => new AdminApi(configuration), [configuration]);
+
+  const resetStatus = useCallback((message: string | null) => {
+    setStatusMessage(message);
   }, []);
+
+  const refreshRequests = useCallback(async () => {
+    if (!token) {
+      setRequests([]);
+      return;
+    }
+
+    setLoading('pending');
+    try {
+      const response = await adminApi.listIssuanceRequests();
+      setRequests(response.items ?? []);
+      resetStatus(null);
+    } catch (error) {
+      console.error('Failed to load issuance requests', error);
+      resetStatus(error instanceof Error ? error.message : 'Unable to load issuance requests.');
+    } finally {
+      setLoading('idle');
+    }
+  }, [adminApi, token, resetStatus]);
+
+  useEffect(() => {
+    if (token) {
+      void refreshRequests();
+    } else {
+      setRequests([]);
+    }
+  }, [token, refreshRequests]);
+
+  const handleConnectionSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setBaseUrl(sanitizeBaseUrl(baseUrlInput));
+      setToken(tokenInput.trim() || null);
+    },
+    [baseUrlInput, tokenInput],
+  );
+
+  const handleRefresh = useCallback(() => {
+    if (!token) {
+      resetStatus('Provide an access token before refreshing the queue.');
+      return;
+    }
+    void refreshRequests();
+  }, [refreshRequests, resetStatus, token]);
+
+  const handleSign = useCallback(
+    async (requestId: string) => {
+      if (!token) {
+        resetStatus('Provide an access token before signing requests.');
+        return;
+      }
+
+      setSigningId(requestId);
+      try {
+        await adminApi.signIssuanceRequest({
+          id: requestId,
+          signIssuanceRequestRequest: { validatorId: selectedValidator },
+        });
+        resetStatus(`Signature recorded for ${requestId} as ${selectedValidator}.`);
+        await refreshRequests();
+      } catch (error) {
+        console.error('Failed to sign issuance request', error);
+        resetStatus(error instanceof Error ? error.message : 'Unable to record signature.');
+      } finally {
+        setSigningId(null);
+      }
+    },
+    [adminApi, refreshRequests, resetStatus, selectedValidator, token],
+  );
+
+  const handleCreateRequest = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!token) {
+        resetStatus('Provide an access token before creating issuance requests.');
+        return;
+      }
+
+      const accountId = accountIdInput.trim();
+      const amountValue = amountInput.trim();
+      const currencyValue = currencyInput.trim() || 'QZD';
+      const reference = referenceInput.trim();
+
+      if (!accountId || !amountValue) {
+        resetStatus('Account ID and amount are required to create an issuance request.');
+        return;
+      }
+
+      setCreateStatus('pending');
+      try {
+        await adminApi.createIssuanceRequest({
+          issueRequest: {
+            accountId,
+            amount: { currency: currencyValue, value: amountValue },
+            reference: reference || undefined,
+          },
+        });
+        setAccountIdInput('');
+        setAmountInput('100.00');
+        setReferenceInput('');
+        resetStatus('Issuance request submitted to the queue.');
+        await refreshRequests();
+      } catch (error) {
+        console.error('Failed to create issuance request', error);
+        resetStatus(error instanceof Error ? error.message : 'Unable to create issuance request.');
+      } finally {
+        setCreateStatus('idle');
+      }
+    },
+    [accountIdInput, adminApi, amountInput, currencyInput, referenceInput, refreshRequests, resetStatus, token],
+  );
 
   return (
     <main>
-      <h1>Admin Console</h1>
-      <ul>
-        {entries.map((entry) => (
-          <li key={entry.tx_hash}>{`${entry.type} ${entry.amount} ${entry.asset} ${entry.memo ?? ''}`}</li>
-        ))}
-      </ul>
+      <h1>Issuance Queue</h1>
+
+      <section>
+        <h2>Connection</h2>
+        <form onSubmit={handleConnectionSubmit}>
+          <label>
+            API base URL
+            <input
+              type="text"
+              value={baseUrlInput}
+              onChange={(event) => setBaseUrlInput(event.target.value)}
+              placeholder={DEFAULT_API_BASE_URL}
+            />
+          </label>
+          <label>
+            Access token
+            <input
+              type="password"
+              value={tokenInput}
+              onChange={(event) => setTokenInput(event.target.value)}
+              placeholder="Paste bearer token"
+            />
+          </label>
+          <button type="submit">Save connection</button>
+        </form>
+      </section>
+
+      <section>
+        <h2>Create issuance request</h2>
+        <form onSubmit={handleCreateRequest}>
+          <label>
+            Account ID
+            <input
+              type="text"
+              value={accountIdInput}
+              onChange={(event) => setAccountIdInput(event.target.value)}
+              placeholder="acct_000001"
+            />
+          </label>
+          <label>
+            Amount
+            <input
+              type="text"
+              value={amountInput}
+              onChange={(event) => setAmountInput(event.target.value)}
+              placeholder="100.00"
+            />
+          </label>
+          <label>
+            Currency
+            <input
+              type="text"
+              value={currencyInput}
+              onChange={(event) => setCurrencyInput(event.target.value)}
+              placeholder="QZD"
+            />
+          </label>
+          <label>
+            Reference (optional)
+            <input
+              type="text"
+              value={referenceInput}
+              onChange={(event) => setReferenceInput(event.target.value)}
+            />
+          </label>
+          <button type="submit" disabled={createStatus === 'pending'}>
+            {createStatus === 'pending' ? 'Submitting…' : 'Submit issuance request'}
+          </button>
+        </form>
+      </section>
+
+      <section>
+        <h2>Validator actions</h2>
+        <div>
+          <label>
+            Validator identity
+            <select
+              value={selectedValidator}
+              onChange={(event) => setSelectedValidator(event.target.value as ValidatorId)}
+            >
+              {KNOWN_VALIDATORS.map((validator) => (
+                <option key={validator} value={validator}>
+                  {validator}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="button" onClick={handleRefresh} disabled={loading === 'pending'}>
+            {loading === 'pending' ? 'Loading…' : 'Refresh queue'}
+          </button>
+        </div>
+        {statusMessage ? <p>{statusMessage}</p> : null}
+        {requests.length === 0 ? (
+          <p>No issuance requests available.</p>
+        ) : (
+          <ul>
+            {requests.map((request) => {
+              const isSigning = signingId === request.id;
+              const signingDisabled = isSigning || request.status === 'completed';
+              return (
+                <li key={request.id}>
+                  <article>
+                    <header>
+                      <h3>{request.id}</h3>
+                    </header>
+                    <dl>
+                      <div>
+                        <dt>Account</dt>
+                        <dd>{request.accountId}</dd>
+                      </div>
+                      <div>
+                        <dt>Amount</dt>
+                        <dd>{formatAmount(request.amount)}</dd>
+                      </div>
+                      <div>
+                        <dt>Progress</dt>
+                        <dd>{formatProgress(request)}</dd>
+                      </div>
+                    </dl>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void handleSign(request.id);
+                      }}
+                      disabled={signingDisabled}
+                    >
+                      {isSigning ? 'Signing…' : `Sign as ${selectedValidator}`}
+                    </button>
+                  </article>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
     </main>
   );
 }

--- a/apps/admin-web/src/setupTests.ts
+++ b/apps/admin-web/src/setupTests.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => {
+  cleanup();
+});

--- a/apps/admin-web/vitest.config.ts
+++ b/apps/admin-web/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 const sdkSrcDir = fileURLToPath(new URL('../../packages/sdk/src/', import.meta.url));
+const sdkBrowserSrcDir = fileURLToPath(new URL('../../packages/sdk-browser/src/', import.meta.url));
 const sharedSrcDir = fileURLToPath(new URL('../../packages/shared/src/', import.meta.url));
 
 export default defineConfig({
@@ -11,24 +12,32 @@ export default defineConfig({
     alias: [
       {
         find: /^@qzd\/sdk$/, // direct entrypoint import
-        replacement: fileURLToPath(new URL('../../packages/sdk/src/index.ts', import.meta.url))
+        replacement: fileURLToPath(new URL('../../packages/sdk/src/index.ts', import.meta.url)),
       },
       {
         find: /^@qzd\/sdk\/(.*)$/,
-        replacement: `${sdkSrcDir}$1`
+        replacement: `${sdkSrcDir}$1`,
+      },
+      {
+        find: /^@qzd\/sdk-browser$/,
+        replacement: fileURLToPath(new URL('../../packages/sdk-browser/src/index.ts', import.meta.url)),
+      },
+      {
+        find: /^@qzd\/sdk-browser\/(.*)$/,
+        replacement: `${sdkBrowserSrcDir}$1`,
       },
       {
         find: /^@qzd\/shared$/,
-        replacement: fileURLToPath(new URL('../../packages/shared/src/index.ts', import.meta.url))
+        replacement: fileURLToPath(new URL('../../packages/shared/src/index.ts', import.meta.url)),
       },
       {
         find: /^@qzd\/shared\/(.*)$/,
-        replacement: `${sharedSrcDir}$1`
-      }
-    ]
+        replacement: `${sharedSrcDir}$1`,
+      },
+    ],
   },
   test: {
     environment: 'jsdom',
-    setupFiles: './src/setupTests.ts'
-  }
+    setupFiles: './src/setupTests.ts',
+  },
 });

--- a/apps/api/src/impl/admin.api.ts
+++ b/apps/api/src/impl/admin.api.ts
@@ -1,15 +1,54 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import type { Observable } from 'rxjs';
 import type { Request } from 'express';
 import { AdminApi } from '@qzd/sdk-api/server';
-import type { ListAdminAlerts200Response } from '@qzd/sdk-api/server';
+import type {
+  IssuanceRequest,
+  IssueRequest,
+  ListAdminAlerts200Response,
+  ListIssuanceRequests200Response,
+  SignIssuanceRequestRequest,
+} from '@qzd/sdk-api/server';
+import { InMemoryBankService, getFallbackBankService } from '../in-memory-bank.service.js';
 
 @Injectable()
 export class AdminApiImpl extends AdminApi {
-  override listAdminAlerts(
+  private readonly bank: InMemoryBankService;
+
+  constructor(@Optional() bank?: InMemoryBankService) {
+    super();
+    this.bank = bank ?? getFallbackBankService();
+  }
+
+  override createIssuanceRequest(
+    issueRequest: IssueRequest,
     request: Request,
+  ): IssuanceRequest | Promise<IssuanceRequest> | Observable<IssuanceRequest> {
+    return this.bank.createIssuanceRequest(issueRequest, request);
+  }
+
+  override listAdminAlerts(
+    _request: Request,
   ): ListAdminAlerts200Response | Promise<ListAdminAlerts200Response> | Observable<ListAdminAlerts200Response> {
-    throw new Error('Method not implemented.');
+    return { alerts: [] } satisfies ListAdminAlerts200Response;
+  }
+
+  override listIssuanceRequests(
+    request: Request,
+  ):
+    | ListIssuanceRequests200Response
+    | Promise<ListIssuanceRequests200Response>
+    | Observable<ListIssuanceRequests200Response> {
+    const items = this.bank.listIssuanceRequests(request);
+    return { items } satisfies ListIssuanceRequests200Response;
+  }
+
+  override signIssuanceRequest(
+    id: string,
+    signIssuanceRequestRequest: SignIssuanceRequestRequest,
+    request: Request,
+  ): IssuanceRequest | Promise<IssuanceRequest> | Observable<IssuanceRequest> {
+    return this.bank.signIssuanceRequest(id, signIssuanceRequestRequest.validatorId, request);
   }
 }

--- a/apps/api/src/impl/ledger.api.ts
+++ b/apps/api/src/impl/ledger.api.ts
@@ -5,8 +5,9 @@ import type { Request } from 'express';
 import { LedgerApi } from '@qzd/sdk-api/server';
 import type {
   Balance,
-  IssueEnvelope,
+  IssuanceRequest,
   IssueRequest,
+  IssueTokensRequest,
   ListValidators200Response,
   RedeemRequest,
   Transaction,
@@ -14,6 +15,13 @@ import type {
 
 @Injectable()
 export class LedgerApiImpl extends LedgerApi {
+  override createIssuanceRequest(
+    _issueRequest: IssueRequest,
+    _request: Request,
+  ): IssuanceRequest | Promise<IssuanceRequest> | Observable<IssuanceRequest> {
+    throw new Error('Method not implemented.');
+  }
+
   override getAccountBalance(
     id: string,
     request: Request,
@@ -22,9 +30,9 @@ export class LedgerApiImpl extends LedgerApi {
   }
 
   override issueTokens(
-    issueRequest: IssueRequest,
-    request: Request,
-  ): IssueEnvelope | Promise<IssueEnvelope> | Observable<IssueEnvelope> {
+    _issueTokensRequest: IssueTokensRequest,
+    _request: Request,
+  ): Transaction | Promise<Transaction> | Observable<Transaction> {
     throw new Error('Method not implemented.');
   }
 

--- a/apps/api/src/impl/transactions.api.ts
+++ b/apps/api/src/impl/transactions.api.ts
@@ -4,8 +4,7 @@ import type { Observable } from 'rxjs';
 import type { Request } from 'express';
 import { TransactionsApi } from '@qzd/sdk-api/server';
 import type {
-  IssueEnvelope,
-  IssueRequest,
+  IssueTokensRequest,
   ListAccountTransactions200Response,
   RedeemRequest,
   Transaction,
@@ -30,10 +29,10 @@ export class TransactionsApiImpl extends TransactionsApi {
   }
 
   override issueTokens(
-    _issueRequest: IssueRequest,
-    _request: Request,
-  ): IssueEnvelope | Promise<IssueEnvelope> | Observable<IssueEnvelope> {
-    throw new BadRequestException('Issuance is not supported in the demo environment');
+    issueTokensRequest: IssueTokensRequest,
+    request: Request,
+  ): Transaction | Promise<Transaction> | Observable<Transaction> {
+    return this.bank.issueFromRequest(issueTokensRequest.requestId, request);
   }
 
   override listAccountTransactions(

--- a/apps/api/src/in-memory-bank.service.ts
+++ b/apps/api/src/in-memory-bank.service.ts
@@ -12,6 +12,8 @@ import type {
   Account,
   Balance,
   CreateAccountRequest,
+  IssueRequest,
+  IssuanceRequest,
   ListAccountTransactions200Response,
   LoginUser200Response,
   LoginUserRequest,
@@ -54,9 +56,23 @@ type TokenRecord = {
   expiresAt: number;
 };
 
+type IssuanceStatus = 'pending' | 'collecting' | 'ready' | 'completed';
+
+type IssuanceRequestRecord = {
+  id: string;
+  accountId: string;
+  currency: string;
+  amount: number;
+  required: number;
+  collected: Set<string>;
+  status: IssuanceStatus;
+  reference?: string;
+};
+
 const DEFAULT_BALANCE = 1_000;
 const TOKEN_TTL_MS = 60 * 60 * 1000;
 const DEFAULT_CURRENCY = 'QZD';
+const ISSUANCE_SIGNATURE_THRESHOLD = 2;
 
 @Injectable()
 export class InMemoryBankService {
@@ -65,10 +81,13 @@ export class InMemoryBankService {
   private readonly accounts = new Map<string, AccountRecord>();
   private readonly transactions = new Map<string, TransactionRecord[]>();
   private readonly tokens = new Map<string, TokenRecord>();
+  private readonly issuanceRequests = new Map<string, IssuanceRequestRecord>();
+  private readonly issuanceOrder: string[] = [];
 
   private userSequence = 1;
   private accountSequence = 1;
   private transactionSequence = 1;
+  private issuanceSequence = 1;
 
   registerUser(request: RegisterUserRequest): RegisterUser201Response {
     const email = request.email?.trim().toLowerCase();
@@ -289,6 +308,123 @@ export class InMemoryBankService {
     return transaction;
   }
 
+  createIssuanceRequest(request: IssueRequest, actor: Request): IssuanceRequest {
+    const user = this.requireUser(actor);
+    const accountId = request.accountId?.trim();
+    const amountValue = request.amount?.value?.trim();
+
+    if (!accountId || !amountValue) {
+      throw new BadRequestException('accountId and amount are required');
+    }
+
+    const account = this.requireAccount(accountId);
+    if (account.ownerId !== user.id) {
+      throw new ForbiddenException('You do not have access to this account');
+    }
+
+    const currency = request.amount?.currency?.trim() || account.currency;
+    if (currency !== account.currency) {
+      throw new BadRequestException('Currency mismatch with account');
+    }
+
+    const amount = this.parsePositiveAmount(amountValue);
+    const reference = request.reference?.trim() || undefined;
+
+    const id = this.buildId('ir', this.issuanceSequence++);
+    const record: IssuanceRequestRecord = {
+      id,
+      accountId,
+      currency,
+      amount,
+      required: ISSUANCE_SIGNATURE_THRESHOLD,
+      collected: new Set(),
+      status: 'pending',
+      reference,
+    } satisfies IssuanceRequestRecord;
+
+    this.issuanceRequests.set(id, record);
+    this.issuanceOrder.unshift(id);
+
+    return this.toIssuanceRequest(record);
+  }
+
+  listIssuanceRequests(actor: Request): IssuanceRequest[] {
+    this.requireUser(actor);
+    return this.issuanceOrder.map((id) =>
+      this.toIssuanceRequest(this.requireIssuanceRequest(id)),
+    );
+  }
+
+  signIssuanceRequest(id: string, validatorId: string, actor: Request): IssuanceRequest {
+    this.requireUser(actor);
+
+    const normalizedId = id?.trim();
+    const normalizedValidator = validatorId?.trim();
+    if (!normalizedId || !normalizedValidator) {
+      throw new BadRequestException('id and validatorId are required');
+    }
+
+    const record = this.requireIssuanceRequest(normalizedId);
+    if (record.status === 'completed') {
+      throw new ConflictException('Issuance request already completed');
+    }
+    if (record.collected.has(normalizedValidator)) {
+      throw new ConflictException('Validator has already signed this request');
+    }
+
+    record.collected.add(normalizedValidator);
+    this.updateIssuanceStatus(record);
+
+    return this.toIssuanceRequest(record);
+  }
+
+  issueFromRequest(requestId: string, actor: Request): Transaction {
+    const user = this.requireUser(actor);
+    const normalizedId = requestId?.trim();
+    if (!normalizedId) {
+      throw new BadRequestException('requestId is required');
+    }
+
+    const record = this.requireIssuanceRequest(normalizedId);
+    if (record.status === 'completed') {
+      throw new ConflictException('Issuance request already completed');
+    }
+    if (record.collected.size < record.required) {
+      throw new BadRequestException('Issuance request is not approved');
+    }
+
+    const account = this.requireAccount(record.accountId);
+    if (account.ownerId !== user.id) {
+      throw new ForbiddenException('You do not have access to this account');
+    }
+
+    const createdAt = new Date().toISOString();
+    account.balance = this.round(account.balance + record.amount);
+    account.updatedAt = createdAt;
+
+    const transactionId = this.buildId('txn', this.transactionSequence++);
+    const metadata: Record<string, string> = { requestId: record.id };
+    if (record.reference) {
+      metadata.reference = record.reference;
+    }
+
+    const transaction: Transaction = {
+      id: transactionId,
+      accountId: account.id,
+      type: 'issuance',
+      status: 'posted',
+      amount: this.monetary(record.amount, record.currency),
+      createdAt,
+      metadata,
+    } satisfies Transaction;
+
+    this.prependTransaction(account.id, transaction);
+
+    record.status = 'completed';
+
+    return transaction;
+  }
+
   private requireAccount(accountId: string): AccountRecord {
     const account = this.accounts.get(accountId);
     if (!account) {
@@ -319,6 +455,14 @@ export class InMemoryBankService {
       throw new UnauthorizedException('Session user no longer exists');
     }
     return user;
+  }
+
+  private requireIssuanceRequest(id: string): IssuanceRequestRecord {
+    const record = this.issuanceRequests.get(id);
+    if (!record) {
+      throw new NotFoundException('Issuance request not found');
+    }
+    return record;
   }
 
   private issueToken(userId: string): string {
@@ -360,6 +504,17 @@ export class InMemoryBankService {
     return { currency, value: amount.toFixed(2) } satisfies MonetaryAmount;
   }
 
+  private toIssuanceRequest(record: IssuanceRequestRecord): IssuanceRequest {
+    return {
+      id: record.id,
+      accountId: record.accountId,
+      amount: this.monetary(record.amount, record.currency),
+      required: record.required,
+      collected: record.collected.size,
+      status: record.status,
+    } satisfies IssuanceRequest;
+  }
+
   private getOrCreateExternalAccount(accountId: string, currency: string): AccountRecord {
     const existing = this.accounts.get(accountId);
     if (existing) {
@@ -396,6 +551,28 @@ export class InMemoryBankService {
       throw new BadRequestException('Invalid cursor');
     }
     return index;
+  }
+
+  private updateIssuanceStatus(record: IssuanceRequestRecord): void {
+    if (record.status === 'completed') {
+      return;
+    }
+    const collected = record.collected.size;
+    if (collected === 0) {
+      record.status = 'pending';
+    } else if (collected < record.required) {
+      record.status = 'collecting';
+    } else {
+      record.status = 'ready';
+    }
+  }
+
+  private parsePositiveAmount(value: string): number {
+    const amount = Number.parseFloat(value);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      throw new BadRequestException('amount must be a positive decimal string');
+    }
+    return this.round(amount);
   }
 
   private buildId(prefix: string, sequence: number): string {

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -411,36 +411,37 @@ paths:
         - Transactions
         - Ledger
       operationId: issueTokens
-      summary: Issue new QZD tokens to an account.
+      summary: Execute an approved issuance request and credit the beneficiary account.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IssueRequest'
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: Identifier of the approved issuance request.
+              required:
+                - requestId
             example:
-              accountId: "acc_987654321"
-              amount:
-                currency: "QZD"
-                value: "1000"
-              reference: "Treasury mint"
+              requestId: "ir_000001"
       responses:
-        '202':
-          description: Issuance request accepted.
+        '200':
+          description: Issuance executed successfully.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IssueEnvelope'
+                $ref: '#/components/schemas/Transaction'
               example:
-                envelopeId: "issue_env_001"
-                status: pending
-                submittedAt: "2024-05-02T11:15:00Z"
-                request:
-                  accountId: "acc_987654321"
-                  amount:
-                    currency: "QZD"
-                    value: "1000"
-                  reference: "Treasury mint"
+                id: "txn_issuance_001"
+                accountId: "acc_987654321"
+                type: issuance
+                amount:
+                  currency: "QZD"
+                  value: "1000"
+                status: posted
+                createdAt: "2024-05-02T11:15:00Z"
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':
@@ -676,6 +677,153 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '403':
           $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /admin/issuance-requests:
+    get:
+      tags:
+        - Admin
+      operationId: listIssuanceRequests
+      summary: List issuance requests awaiting validator review.
+      responses:
+        '200':
+          description: Issuance requests retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/IssuanceRequest'
+              example:
+                items:
+                  - id: "ir_000001"
+                    accountId: "acc_987654321"
+                    amount:
+                      currency: "QZD"
+                      value: "1000"
+                    required: 2
+                    collected: 1
+                    status: collecting
+                  - id: "ir_000002"
+                    accountId: "acc_222222222"
+                    amount:
+                      currency: "QZD"
+                      value: "500"
+                    required: 2
+                    collected: 2
+                    status: ready
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Admin
+        - Ledger
+      operationId: createIssuanceRequest
+      summary: Submit a new issuance request to the validator queue.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IssueRequest'
+            example:
+              accountId: "acc_987654321"
+              amount:
+                currency: "QZD"
+                value: "1000"
+              reference: "Treasury mint"
+      responses:
+        '201':
+          description: Issuance request created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssuanceRequest'
+              example:
+                id: "ir_000001"
+                accountId: "acc_987654321"
+                amount:
+                  currency: "QZD"
+                  value: "1000"
+                required: 2
+                collected: 0
+                status: pending
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /admin/issuance-requests/{id}/sign:
+    post:
+      tags:
+        - Admin
+      operationId: signIssuanceRequest
+      summary: Record a validator signature for the issuance request.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Identifier of the issuance request to sign.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                validatorId:
+                  type: string
+                  description: Identifier of the validator providing the signature.
+              required:
+                - validatorId
+            example:
+              validatorId: "validator-1"
+      responses:
+        '200':
+          description: Signature recorded successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IssuanceRequest'
+              example:
+                id: "ir_000001"
+                accountId: "acc_987654321"
+                amount:
+                  currency: "QZD"
+                  value: "1000"
+                required: 2
+                collected: 1
+                status: collecting
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '409':
+          $ref: '#/components/responses/ConflictError'
         '429':
           $ref: '#/components/responses/TooManyRequestsError'
         '500':
@@ -1022,6 +1170,38 @@ components:
         - status
         - submittedAt
         - request
+    IssuanceRequest:
+      type: object
+      description: Track validator approvals for a queued issuance.
+      properties:
+        id:
+          type: string
+        accountId:
+          type: string
+        amount:
+          $ref: '#/components/schemas/MonetaryAmount'
+        required:
+          type: integer
+          format: int32
+          description: Number of validator signatures required for approval.
+        collected:
+          type: integer
+          format: int32
+          description: Number of validator signatures collected so far.
+        status:
+          type: string
+          enum:
+            - pending
+            - collecting
+            - ready
+            - completed
+      required:
+        - id
+        - accountId
+        - amount
+        - required
+        - collected
+        - status
     RedeemRequest:
       type: object
       properties:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,9 @@ importers:
 
   apps/admin-web:
     dependencies:
-      '@qzd/sdk':
+      '@qzd/sdk-browser':
         specifier: workspace:*
-        version: link:../../packages/sdk
+        version: link:../../packages/sdk-browser
       '@qzd/shared':
         specifier: workspace:*
         version: link:../../packages/shared


### PR DESCRIPTION
## Summary
- extend the OpenAPI spec with issuance request endpoints and regenerate shared types
- implement an in-memory issuance queue with admin APIs and transaction execution using the generated contracts
- refresh the admin web console to create, list, and sign issuance requests via the browser SDK

## Testing
- pnpm --filter @qzd/api test
- pnpm --filter @qzd/admin-web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d71b50685c8330bc55848bbd508f6b