### PR TITLE
feat: add agent cash operations and voucher redemption

### DIFF
--- a/apps/admin-web/src/App.test.tsx
+++ b/apps/admin-web/src/App.test.tsx
@@ -9,12 +9,23 @@ vi.mock('@qzd/sdk-browser', () => {
     createIssuanceRequest = vi.fn().mockResolvedValue({});
   }
 
+  class MockAgentsApi {
+    redeemVoucher = vi.fn().mockResolvedValue({
+      code: 'vch_test',
+      amount: { currency: 'QZD', value: '0.00' },
+      fee: { currency: 'QZD', value: '0.00' },
+      totalDebited: { currency: 'QZD', value: '0.00' },
+      status: 'issued',
+      createdAt: '2024-01-01T00:00:00Z',
+    });
+  }
+
   class MockConfiguration {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     constructor() {}
   }
 
-  return { AdminApi: MockAdminApi, Configuration: MockConfiguration };
+  return { AdminApi: MockAdminApi, AgentsApi: MockAgentsApi, Configuration: MockConfiguration };
 });
 
 describe('Admin App', () => {
@@ -23,6 +34,7 @@ describe('Admin App', () => {
 
     expect(screen.getByRole('heading', { level: 1, name: /issuance queue/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 2, name: /connection/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /voucher redemption/i })).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { level: 2, name: /create issuance request/i }),
     ).toBeInTheDocument();
@@ -34,6 +46,7 @@ describe('Admin App', () => {
 
     expect(screen.getByPlaceholderText('http://localhost:3000')).toHaveValue('http://localhost:3000');
     expect(screen.getByPlaceholderText('Paste bearer token')).toHaveValue('');
+    expect(screen.getByPlaceholderText('vch_000001')).toHaveValue('');
     expect(screen.getByRole('combobox', { name: /validator identity/i })).toHaveDisplayValue('validator-1');
   });
 
@@ -41,5 +54,6 @@ describe('Admin App', () => {
     render(<App />);
 
     expect(screen.getAllByText(/no issuance requests available/i)[0]).toBeInTheDocument();
+    expect(screen.getByText(/no voucher redeemed yet/i)).toBeInTheDocument();
   });
 });

--- a/apps/api/src/flows.e2e.spec.ts
+++ b/apps/api/src/flows.e2e.spec.ts
@@ -72,4 +72,87 @@ describe('Wallet flows', () => {
     expect(Array.isArray(transactionsResponse.body.items)).toBe(true);
     expect(transactionsResponse.body.items.length).toBeGreaterThan(0);
   });
+
+  it('supports agent cash-in, cash-out, and voucher redemption flows', async () => {
+    const email = `agent${Date.now()}@example.com`;
+    const password = 'Pass1234!';
+    const fullName = 'Agent User';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const client = () => supertest(server) as any;
+
+    const registerResponse = await client()
+      .post('/auth/register')
+      .send({ email, password, fullName })
+      .expect(201);
+
+    const token = registerResponse.body.token as string;
+    const accountId = registerResponse.body.account?.id as string;
+
+    const balanceResponse = await client()
+      .get(`/accounts/${accountId}/balance`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const startingBalance = Number.parseFloat(balanceResponse.body.total.value as string);
+
+    const cashInResponse = await client()
+      .post('/agents/cashin')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        accountId,
+        amount: { currency: 'QZD', value: '200.00' },
+        memo: 'Float top-up',
+      })
+      .expect(201);
+
+    expect(cashInResponse.body.type).toBe('credit');
+
+    const postCashInBalance = await client()
+      .get(`/accounts/${accountId}/balance`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const balanceAfterCashIn = Number.parseFloat(postCashInBalance.body.total.value as string);
+    expect(balanceAfterCashIn).toBeCloseTo(startingBalance + 200, 2);
+
+    const cashOutResponse = await client()
+      .post('/agents/cashout')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        accountId,
+        amount: { currency: 'QZD', value: '100.00' },
+        memo: 'Branch disbursement',
+      })
+      .expect(201);
+
+    const voucherCode = cashOutResponse.body.code as string;
+    expect(voucherCode).toMatch(/^vch_/);
+    expect(cashOutResponse.body.fee.value).toBe('0.50');
+
+    const postCashOutBalance = await client()
+      .get(`/accounts/${accountId}/balance`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const balanceAfterCashOut = Number.parseFloat(postCashOutBalance.body.total.value as string);
+    expect(balanceAfterCashOut).toBeCloseTo(balanceAfterCashIn - 100.5, 2);
+
+    const redeemResponse = await client()
+      .post(`/agents/vouchers/${voucherCode}/redeem`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(201);
+
+    expect(redeemResponse.body.status).toBe('redeemed');
+    expect(redeemResponse.body.code).toBe(voucherCode);
+
+    const transactionsResponse = await client()
+      .get(`/accounts/${accountId}/transactions`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    const items = transactionsResponse.body.items as Array<{ type: string; metadata?: Record<string, string> }>;
+    expect(items[0]?.type).toBe('redemption');
+    expect(items[0]?.metadata?.voucherCode).toBe(voucherCode);
+    expect(items[1]?.metadata?.feeValue).toBe('0.50');
+  });
 });

--- a/apps/api/src/impl/agents.api.ts
+++ b/apps/api/src/impl/agents.api.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Injectable, Optional } from '@nestjs/common';
+import type { Observable } from 'rxjs';
+import type { Request } from 'express';
+import { AgentsApi } from '@qzd/sdk-api/server';
+import type {
+  AgentCashInRequest,
+  AgentCashOutRequest,
+  Transaction,
+  Voucher,
+} from '@qzd/sdk-api/server';
+import { InMemoryBankService, getFallbackBankService } from '../in-memory-bank.service.js';
+
+@Injectable()
+export class AgentsApiImpl extends AgentsApi {
+  private readonly bank: InMemoryBankService;
+
+  constructor(@Optional() bank?: InMemoryBankService) {
+    super();
+    this.bank = bank ?? getFallbackBankService();
+  }
+
+  override agentCashIn(
+    agentCashInRequest: AgentCashInRequest,
+    request: Request,
+  ): Transaction | Promise<Transaction> | Observable<Transaction> {
+    return this.bank.agentCashIn(agentCashInRequest, request);
+  }
+
+  override agentCashOut(
+    agentCashOutRequest: AgentCashOutRequest,
+    request: Request,
+  ): Voucher | Promise<Voucher> | Observable<Voucher> {
+    return this.bank.agentCashOut(agentCashOutRequest, request);
+  }
+
+  override redeemVoucher(
+    code: string,
+    request: Request,
+  ): Voucher | Promise<Voucher> | Observable<Voucher> {
+    return this.bank.redeemVoucher(code, request);
+  }
+}

--- a/apps/api/src/impl/index.ts
+++ b/apps/api/src/impl/index.ts
@@ -1,5 +1,6 @@
 import type { ApiImplementations } from '@qzd/sdk-api/server';
 import { AccountsApiImpl } from './accounts.api.js';
+import { AgentsApiImpl } from './agents.api.js';
 import { AdminApiImpl } from './admin.api.js';
 import { AuthApiImpl } from './auth.api.js';
 import { HealthApiImpl } from './health.api.js';
@@ -9,6 +10,7 @@ import { TransactionsApiImpl } from './transactions.api.js';
 
 export const apiImplementations: ApiImplementations = {
   accountsApi: AccountsApiImpl,
+  agentsApi: AgentsApiImpl,
   adminApi: AdminApiImpl,
   authApi: AuthApiImpl,
   healthApi: HealthApiImpl,
@@ -19,6 +21,7 @@ export const apiImplementations: ApiImplementations = {
 
 export {
   AccountsApiImpl,
+  AgentsApiImpl,
   AdminApiImpl,
   AuthApiImpl,
   HealthApiImpl,

--- a/apps/api/src/register-generated-metadata.ts
+++ b/apps/api/src/register-generated-metadata.ts
@@ -4,6 +4,8 @@ import {
   AccountsApiController,
   AdminApi,
   AdminApiController,
+  AgentsApi,
+  AgentsApiController,
   AuthApi,
   AuthApiController,
   HealthApi,
@@ -22,6 +24,7 @@ type ApiConstructor = abstract new (...args: any[]) => unknown; // eslint-disabl
 const controllerBindings: ReadonlyArray<readonly [ControllerConstructor, ApiConstructor]> = [
   [AccountsApiController, AccountsApi],
   [AdminApiController, AdminApi],
+  [AgentsApiController, AgentsApi],
   [AuthApiController, AuthApi],
   [HealthApiController, HealthApi],
   [LedgerApiController, LedgerApi],

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "preserveSymlinks": true
+    "preserveSymlinks": true,
+    "types": ["node", "supertest"]
   },
   "include": ["src/**/*", "vitest.config.ts"],
   "exclude": ["dist", "node_modules"]

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -28,6 +28,8 @@ tags:
     description: Cross-border remittance flows and related quote operations.
   - name: Admin
     description: Administrative visibility and alert management endpoints.
+  - name: Agents
+    description: Agent cash-in, cash-out, and voucher reconciliation workflows.
   - name: Health
     description: Service health and readiness probes.
 paths:
@@ -494,6 +496,156 @@ paths:
                   value: "500"
                 status: pending
                 createdAt: "2024-05-02T11:30:00Z"
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /agents/cashin:
+    post:
+      tags:
+        - Agents
+      operationId: agentCashIn
+      summary: Accept cash-in from an agent and credit their QZD balance.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentCashInRequest'
+            example:
+              accountId: "acc_987654321"
+              amount:
+                currency: "QZD"
+                value: "250.00"
+              memo: "Float top-up"
+      responses:
+        '201':
+          description: Cash-in recorded successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+              example:
+                id: "txn_cash_in_001"
+                accountId: "acc_987654321"
+                type: credit
+                amount:
+                  currency: "QZD"
+                  value: "250.00"
+                status: posted
+                createdAt: "2024-05-02T12:00:00Z"
+                metadata:
+                  memo: "Float top-up"
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /agents/cashout:
+    post:
+      tags:
+        - Agents
+      operationId: agentCashOut
+      summary: Convert QZD balance into a voucher code for payout.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentCashOutRequest'
+            example:
+              accountId: "acc_987654321"
+              amount:
+                currency: "QZD"
+                value: "100.00"
+              memo: "Branch disbursement"
+      responses:
+        '201':
+          description: Voucher issued for cash out.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Voucher'
+              example:
+                code: "vch_000123"
+                accountId: "acc_987654321"
+                amount:
+                  currency: "QZD"
+                  value: "100.00"
+                fee:
+                  currency: "QZD"
+                  value: "0.50"
+                totalDebited:
+                  currency: "QZD"
+                  value: "100.50"
+                status: issued
+                createdAt: "2024-05-02T12:05:00Z"
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /agents/vouchers/{code}/redeem:
+    post:
+      tags:
+        - Agents
+      operationId: redeemVoucher
+      summary: Redeem an issued voucher code and finalize payout.
+      parameters:
+        - name: code
+          in: path
+          required: true
+          description: Voucher code issued during agent cash-out.
+          schema:
+            type: string
+      responses:
+        '201':
+          description: Voucher redeemed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Voucher'
+              example:
+                code: "vch_000123"
+                accountId: "acc_987654321"
+                amount:
+                  currency: "QZD"
+                  value: "100.00"
+                fee:
+                  currency: "QZD"
+                  value: "0.50"
+                totalDebited:
+                  currency: "QZD"
+                  value: "100.50"
+                status: redeemed
+                createdAt: "2024-05-02T12:05:00Z"
+                redeemedAt: "2024-05-02T12:15:00Z"
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':
@@ -1137,6 +1289,32 @@ components:
         - sourceAccountId
         - destinationAccountId
         - amount
+    AgentCashInRequest:
+      type: object
+      properties:
+        accountId:
+          type: string
+        amount:
+          $ref: '#/components/schemas/MonetaryAmount'
+        memo:
+          type: string
+          description: Optional note describing the cash-in event.
+      required:
+        - accountId
+        - amount
+    AgentCashOutRequest:
+      type: object
+      properties:
+        accountId:
+          type: string
+        amount:
+          $ref: '#/components/schemas/MonetaryAmount'
+        memo:
+          type: string
+          description: Optional note describing the disbursement.
+      required:
+        - accountId
+        - amount
     IssueRequest:
       type: object
       properties:
@@ -1198,6 +1376,44 @@ components:
       required:
         - id
         - accountId
+    Voucher:
+      type: object
+      properties:
+        code:
+          type: string
+        accountId:
+          type: string
+        amount:
+          $ref: '#/components/schemas/MonetaryAmount'
+        fee:
+          $ref: '#/components/schemas/MonetaryAmount'
+        totalDebited:
+          $ref: '#/components/schemas/MonetaryAmount'
+        status:
+          type: string
+          enum:
+            - issued
+            - redeemed
+        createdAt:
+          type: string
+          format: date-time
+        redeemedAt:
+          type: string
+          format: date-time
+          description: Timestamp when the voucher was redeemed.
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+          description: Additional context captured during issuance or redemption.
+      required:
+        - code
+        - accountId
+        - amount
+        - fee
+        - totalDebited
+        - status
+        - createdAt
         - amount
         - required
         - collected


### PR DESCRIPTION
## Summary
- extend the OpenAPI spec with agent cash-in/cash-out and voucher redemption endpoints and regenerate shared types
- implement agent cash handling in the in-memory bank plus a new Agents API implementation
- add voucher redemption controls to the admin UI with updated tests

## Testing
- pnpm --filter @qzd/api test
- pnpm --filter @qzd/admin-web test

------
https://chatgpt.com/codex/tasks/task_e_68d7269d4d4c8330ba3bc02731a112ae