### PR TITLE
Add SMS inbound API handling and simulator

### DIFF
--- a/apps/api/src/impl/index.ts
+++ b/apps/api/src/impl/index.ts
@@ -6,6 +6,7 @@ import { AuthApiImpl } from './auth.api.js';
 import { HealthApiImpl } from './health.api.js';
 import { LedgerApiImpl } from './ledger.api.js';
 import { RemittancesApiImpl } from './remittances.api.js';
+import { SmsApiImpl } from './sms.api.js';
 import { TransactionsApiImpl } from './transactions.api.js';
 
 export const apiImplementations: ApiImplementations = {
@@ -16,6 +17,7 @@ export const apiImplementations: ApiImplementations = {
   healthApi: HealthApiImpl,
   ledgerApi: LedgerApiImpl,
   remittancesApi: RemittancesApiImpl,
+  smsApi: SmsApiImpl,
   transactionsApi: TransactionsApiImpl,
 };
 
@@ -27,5 +29,6 @@ export {
   HealthApiImpl,
   LedgerApiImpl,
   RemittancesApiImpl,
+  SmsApiImpl,
   TransactionsApiImpl,
 };

--- a/apps/api/src/impl/sms.api.ts
+++ b/apps/api/src/impl/sms.api.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Injectable, Optional } from '@nestjs/common';
+import type { Observable } from 'rxjs';
+import type { Request } from 'express';
+import { SmsApi } from '@qzd/sdk-api/server';
+import type { SmsInboundRequest, SmsInboundResponse } from '@qzd/sdk-api/server';
+import { InMemoryBankService, getFallbackBankService } from '../in-memory-bank.service.js';
+
+@Injectable()
+export class SmsApiImpl extends SmsApi {
+  private readonly bank: InMemoryBankService;
+
+  constructor(@Optional() bank?: InMemoryBankService) {
+    super();
+    this.bank = bank ?? getFallbackBankService();
+  }
+
+  override receiveSmsInbound(
+    smsInboundRequest: SmsInboundRequest,
+    request: Request,
+  ): SmsInboundResponse | Promise<SmsInboundResponse> | Observable<SmsInboundResponse> {
+    return this.bank.receiveSmsInbound(smsInboundRequest, request);
+  }
+}

--- a/apps/sms-sim/package.json
+++ b/apps/sms-sim/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@qzd/sms-sim",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.mjs"
+  }
+}

--- a/apps/sms-sim/src/index.mjs
+++ b/apps/sms-sim/src/index.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+import { createInterface } from 'node:readline/promises';
+import { stdin, stdout, stderr, exit } from 'node:process';
+
+const args = process.argv.slice(2);
+let baseUrl = process.env.SMS_SIM_API_BASE ?? 'http://localhost:3000';
+let from = process.env.SMS_SIM_FROM ?? '5025551000';
+
+const usage = () => {
+  stdout.write('Usage: pnpm --filter @qzd/sms-sim start -- [--base <url>] [--from <msisdn>]\\n');
+  stdout.write('Commands inside the prompt: /from <msisdn>, /base <url>, /quit to exit.\\n');
+};
+
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  switch (arg) {
+    case '--base':
+    case '-b': {
+      const value = args[i + 1];
+      if (!value) {
+        stderr.write('Missing value for --base option.\\n');
+        usage();
+        exit(1);
+      }
+      baseUrl = value;
+      i += 1;
+      break;
+    }
+    case '--from':
+    case '-f': {
+      const value = args[i + 1];
+      if (!value) {
+        stderr.write('Missing value for --from option.\\n');
+        usage();
+        exit(1);
+      }
+      from = value;
+      i += 1;
+      break;
+    }
+    case '--help':
+    case '-h': {
+      usage();
+      exit(0);
+    }
+    default: {
+      if (arg.startsWith('-')) {
+        stderr.write(`Unknown option: ${arg}\\n`);
+        usage();
+        exit(1);
+      }
+    }
+  }
+}
+
+const normalizeBaseUrl = (url) => url.endsWith('/') ? url.slice(0, -1) : url;
+
+baseUrl = normalizeBaseUrl(baseUrl);
+
+const rl = createInterface({ input: stdin, output: stdout, terminal: true });
+
+stdout.write(`SMS simulator ready. Forwarding from ${from} to ${baseUrl}/sms/inbound\\n`);
+stdout.write('Type an SMS command (BAL, SEND 50 502xxxx, etc.). Prefix with /from or /base to change sender or target.\\n');
+stdout.write('Type /quit to exit.\\n');
+
+const sendSms = async (text) => {
+  const response = await fetch(`${baseUrl}/sms/inbound`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ from, text }),
+  });
+
+  if (!response.ok) {
+    const message = await safeReadError(response);
+    throw new Error(`API error ${response.status}: ${message}`);
+  }
+
+  const data = await response.json();
+  if (!data || typeof data.reply !== 'string') {
+    throw new Error('Malformed response from API.');
+  }
+  return data.reply;
+};
+
+const safeReadError = async (response) => {
+  try {
+    const payload = await response.json();
+    if (payload && typeof payload.message === 'string') {
+      return payload.message;
+    }
+  } catch {
+    // ignore JSON parse errors
+  }
+  return response.statusText || 'Unknown error';
+};
+
+try {
+  for await (const line of rl) {
+    const input = line.trim();
+    if (!input) {
+      continue;
+    }
+
+    if (input === '/quit' || input === '/exit') {
+      break;
+    }
+
+    if (input.startsWith('/from ')) {
+      const newFrom = input.slice(6).trim();
+      if (!newFrom) {
+        stdout.write('Usage: /from <msisdn>\\n');
+        continue;
+      }
+      from = newFrom;
+      stdout.write(`Sender updated to ${from}.\\n`);
+      continue;
+    }
+
+    if (input.startsWith('/base ')) {
+      const newBase = input.slice(6).trim();
+      if (!newBase) {
+        stdout.write('Usage: /base <url>\\n');
+        continue;
+      }
+      baseUrl = normalizeBaseUrl(newBase);
+      stdout.write(`API base updated to ${baseUrl}.\\n`);
+      continue;
+    }
+
+    try {
+      const reply = await sendSms(input);
+      stdout.write(`<< ${reply}\\n`);
+    } catch (error) {
+      stderr.write(`!! ${error.message ?? error}\\n`);
+    }
+  }
+} finally {
+  rl.close();
+  stdout.write('Goodbye!\\n');
+}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -30,6 +30,8 @@ tags:
     description: Administrative visibility and alert management endpoints.
   - name: Agents
     description: Agent cash-in, cash-out, and voucher reconciliation workflows.
+  - name: Sms
+    description: Inbound SMS command processing and responses.
   - name: Health
     description: Service health and readiness probes.
 paths:
@@ -1054,6 +1056,37 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
       security: []
+  /sms/inbound:
+    post:
+      tags:
+        - Sms
+      operationId: receiveSmsInbound
+      summary: Forward an inbound SMS command for processing.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SmsInboundRequest'
+            example:
+              from: "5025551234"
+              text: "BAL"
+      responses:
+        '200':
+          description: SMS command processed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SmsInboundResponse'
+              example:
+                reply: "Balance: QZD 1,000.00"
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '429':
+          $ref: '#/components/responses/TooManyRequestsError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      security: []
 components:
   securitySchemes:
     BearerAuth:
@@ -1524,6 +1557,28 @@ components:
         - severity
         - message
         - createdAt
+    SmsInboundRequest:
+      type: object
+      description: Inbound SMS payload forwarded from the messaging gateway.
+      properties:
+        from:
+          type: string
+          description: MSISDN of the sender initiating the command.
+        text:
+          type: string
+          description: Body of the received SMS message.
+      required:
+        - from
+        - text
+    SmsInboundResponse:
+      type: object
+      description: Response payload containing the SMS reply text.
+      properties:
+        reply:
+          type: string
+          description: Text that should be sent back to the sender.
+      required:
+        - reply
     Error:
       type: object
       properties:

--- a/packages/shared/src/oas-types.ts
+++ b/packages/shared/src/oas-types.ts
@@ -351,6 +351,23 @@ export type paths = {
         patch?: never;
         trace?: never;
     };
+    "/sms/inbound": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Forward an inbound SMS command for processing. */
+        post: operations["receiveSmsInbound"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 };
 export type webhooks = Record<string, never>;
 export type components = {
@@ -526,6 +543,18 @@ export type components = {
             message: string;
             /** Format: date-time */
             createdAt: string;
+        };
+        /** @description Inbound SMS payload forwarded from the messaging gateway. */
+        SmsInboundRequest: {
+            /** @description MSISDN of the sender initiating the command. */
+            from: string;
+            /** @description Body of the received SMS message. */
+            text: string;
+        };
+        /** @description Response payload containing the SMS reply text. */
+        SmsInboundResponse: {
+            /** @description Text that should be sent back to the sender. */
+            reply: string;
         };
         Error: {
             /** @enum {string} */
@@ -1676,6 +1705,40 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+        };
+    };
+    receiveSmsInbound: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                /** @example {
+                 *       "from": "5025551234",
+                 *       "text": "BAL"
+                 *     } */
+                "application/json": components["schemas"]["SmsInboundRequest"];
+            };
+        };
+        responses: {
+            /** @description SMS command processed successfully. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /** @example {
+                     *       "reply": "Balance: QZD 1,000.00"
+                     *     } */
+                    "application/json": components["schemas"]["SmsInboundResponse"];
+                };
+            };
+            400: components["responses"]["BadRequestError"];
+            429: components["responses"]["TooManyRequestsError"];
+            500: components["responses"]["InternalServerError"];
         };
     };
 }


### PR DESCRIPTION
## Summary
- extend the OpenAPI specification with /sms/inbound and new Sms tag/schemas
- implement SMS command handling in the in-memory bank and register the SmsApi implementation
- add an sms-sim workspace CLI that forwards simulated messages to the API endpoint

## Testing
- pnpm --filter @qzd/api test

------
https://chatgpt.com/codex/tasks/task_e_68d833f0a92083308f01f75981fdf179