### PR TITLE
Add request security enforcement and idempotency support

### DIFF
--- a/apps/api/src/flows.e2e.spec.ts
+++ b/apps/api/src/flows.e2e.spec.ts
@@ -1,8 +1,84 @@
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { randomBytes, randomUUID } from 'node:crypto';
 import supertest from 'supertest';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ed25519 } from '@noble/curves/ed25519';
+import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import { AppModule } from './app.module.js';
+import {
+  DEV_SIGNING_KEYPAIR,
+  createSignaturePayload,
+  serializeBody,
+} from './request-security.js';
+
+type SecurityOverrides = {
+  idempotencyKey?: string;
+  nonce?: string;
+};
+
+interface SecurityHeaders {
+  idempotencyKey: string;
+  nonce: string;
+  signature: string;
+}
+
+function buildSecurityHeaders(
+  method: string,
+  path: string,
+  body: unknown,
+  overrides: SecurityOverrides = {},
+): SecurityHeaders {
+  const idempotencyKey = overrides.idempotencyKey ?? `idem-${randomUUID()}`;
+  const nonce = overrides.nonce ?? bytesToHex(randomBytes(16));
+  const serializedBody = serializeBody(body);
+  const payload = createSignaturePayload({
+    method,
+    path,
+    idempotencyKey,
+    nonce,
+    serializedBody,
+  });
+  const signature = bytesToHex(
+    ed25519.sign(payload, hexToBytes(DEV_SIGNING_KEYPAIR.privateKey)),
+  );
+  return { idempotencyKey, nonce, signature };
+}
+
+type HeaderValue = string | number | readonly string[];
+
+type ResponseWithBody = { status: number; body: Record<string, unknown> };
+
+type ChainableTest = supertest.Test &
+  PromiseLike<ResponseWithBody> & {
+    set(field: string, value: HeaderValue): ChainableTest;
+    set(fields: Record<string, HeaderValue>): ChainableTest;
+    send(body?: unknown): ChainableTest;
+  };
+
+type TestClient = {
+  post(path: string): ChainableTest;
+  get(path: string): ChainableTest;
+};
+
+function getResponseBody<T extends Record<string, unknown>>(response: ResponseWithBody): T {
+  return response.body as T;
+}
+
+function applySecurity(
+  request: ChainableTest,
+  method: string,
+  path: string,
+  body: unknown,
+  overrides: SecurityOverrides = {},
+): { request: ChainableTest; headers: SecurityHeaders } {
+  const headers = buildSecurityHeaders(method, path, body, overrides);
+  request
+    .set('Idempotency-Key', headers.idempotencyKey)
+    .set('X-QZD-Nonce', headers.nonce)
+    .set('X-QZD-Signature', headers.signature);
+  return { request, headers };
+}
 
 describe('Wallet flows', () => {
   let app: INestApplication;
@@ -26,133 +102,324 @@ describe('Wallet flows', () => {
     const email = `user${Date.now()}@example.com`;
     const password = 'Pass1234!';
     const fullName = 'Test User';
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const client = () => supertest(server) as any;
+    const client = (): TestClient => supertest(server) as unknown as TestClient;
 
-    const registerResponse = await client()
-      .post('/auth/register')
-      .send({ email, password, fullName })
-      .expect(201);
+    const registerBody = { email, password, fullName };
+    const { request: registerRequest } = applySecurity(
+      client().post('/auth/register'),
+      'POST',
+      '/auth/register',
+      registerBody,
+    );
+    const registerResponse = await registerRequest.send(registerBody).expect(201);
+    const registerPayload = getResponseBody<{
+      token?: string;
+      account?: { id?: string };
+    }>(registerResponse);
 
-    const token = registerResponse.body.token as string;
+    const token = registerPayload.token as string;
     expect(token).toBeTruthy();
-    const accountId = registerResponse.body.account?.id as string;
+    const accountId = registerPayload.account?.id as string;
     expect(accountId).toBeTruthy();
 
-    const loginResponse = await client()
-      .post('/auth/login')
-      .send({ email, password });
+    const loginBody = { email, password };
+    const { request: loginRequest } = applySecurity(
+      client().post('/auth/login'),
+      'POST',
+      '/auth/login',
+      loginBody,
+    );
+    const loginResponse = await loginRequest.send(loginBody);
     expect([200, 201]).toContain(loginResponse.status);
-    expect(loginResponse.body.token).toBeTruthy();
+    const loginPayload = getResponseBody<{ token?: string }>(loginResponse);
+    expect(loginPayload.token).toBeTruthy();
 
     const balanceResponse = await client()
       .get(`/accounts/${accountId}/balance`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
-    expect(balanceResponse.body.accountId).toBe(accountId);
+    const balancePayload = getResponseBody<{ accountId?: string }>(balanceResponse);
+    expect(balancePayload.accountId).toBe(accountId);
 
-    const transferResponse = await client()
-      .post('/tx/transfer')
+    const transferBody = {
+      sourceAccountId: accountId,
+      destinationAccountId: `${accountId}-dest`,
+      amount: { currency: 'QZD', value: '10.00' },
+    } as const;
+    const { request: transferRequest } = applySecurity(
+      client().post('/tx/transfer'),
+      'POST',
+      '/tx/transfer',
+      transferBody,
+    );
+    const transferResponse = await transferRequest
       .set('Authorization', `Bearer ${token}`)
-      .send({
-        sourceAccountId: accountId,
-        destinationAccountId: `${accountId}-dest`,
-        amount: { currency: 'QZD', value: '10.00' },
-      })
+      .send(transferBody)
       .expect(201);
 
-    expect(transferResponse.body.id).toBeTruthy();
+    const transferPayload = getResponseBody<{ id?: string }>(transferResponse);
+    expect(transferPayload.id).toBeTruthy();
 
     const transactionsResponse = await client()
       .get(`/accounts/${accountId}/transactions`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
-    expect(Array.isArray(transactionsResponse.body.items)).toBe(true);
-    expect(transactionsResponse.body.items.length).toBeGreaterThan(0);
+    const transactionsPayload = getResponseBody<{ items?: unknown[] }>(transactionsResponse);
+    expect(Array.isArray(transactionsPayload.items)).toBe(true);
+    expect((transactionsPayload.items ?? []).length).toBeGreaterThan(0);
   });
 
   it('supports agent cash-in, cash-out, and voucher redemption flows', async () => {
     const email = `agent${Date.now()}@example.com`;
     const password = 'Pass1234!';
     const fullName = 'Agent User';
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const client = () => supertest(server) as any;
+    const client = (): TestClient => supertest(server) as unknown as TestClient;
 
-    const registerResponse = await client()
-      .post('/auth/register')
-      .send({ email, password, fullName })
-      .expect(201);
+    const registerBody = { email, password, fullName };
+    const { request: registerRequest } = applySecurity(
+      client().post('/auth/register'),
+      'POST',
+      '/auth/register',
+      registerBody,
+    );
+    const registerResponse = await registerRequest.send(registerBody).expect(201);
+    const registerPayload = getResponseBody<{
+      token?: string;
+      account?: { id?: string };
+    }>(registerResponse);
 
-    const token = registerResponse.body.token as string;
-    const accountId = registerResponse.body.account?.id as string;
+    const token = registerPayload.token as string;
+    const accountId = registerPayload.account?.id as string;
 
     const balanceResponse = await client()
       .get(`/accounts/${accountId}/balance`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
-    const startingBalance = Number.parseFloat(balanceResponse.body.total.value as string);
+    const balancePayload = getResponseBody<{ total?: { value?: string } }>(balanceResponse);
+    const startingBalance = Number.parseFloat((balancePayload.total?.value as string) ?? '0');
 
-    const cashInResponse = await client()
-      .post('/agents/cashin')
+    const cashInBody = {
+      accountId,
+      amount: { currency: 'QZD', value: '200.00' },
+      memo: 'Float top-up',
+    } as const;
+    const { request: cashInRequest } = applySecurity(
+      client().post('/agents/cashin'),
+      'POST',
+      '/agents/cashin',
+      cashInBody,
+    );
+    const cashInResponse = await cashInRequest
       .set('Authorization', `Bearer ${token}`)
-      .send({
-        accountId,
-        amount: { currency: 'QZD', value: '200.00' },
-        memo: 'Float top-up',
-      })
+      .send(cashInBody)
       .expect(201);
 
-    expect(cashInResponse.body.type).toBe('credit');
+    const cashInPayload = getResponseBody<{ type?: string }>(cashInResponse);
+    expect(cashInPayload.type).toBe('credit');
 
     const postCashInBalance = await client()
       .get(`/accounts/${accountId}/balance`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
-    const balanceAfterCashIn = Number.parseFloat(postCashInBalance.body.total.value as string);
+    const postCashInPayload = getResponseBody<{ total?: { value?: string } }>(postCashInBalance);
+    const balanceAfterCashIn = Number.parseFloat((postCashInPayload.total?.value as string) ?? '0');
     expect(balanceAfterCashIn).toBeCloseTo(startingBalance + 200, 2);
 
-    const cashOutResponse = await client()
-      .post('/agents/cashout')
+    const cashOutBody = {
+      accountId,
+      amount: { currency: 'QZD', value: '100.00' },
+      memo: 'Branch disbursement',
+    } as const;
+    const { request: cashOutRequest } = applySecurity(
+      client().post('/agents/cashout'),
+      'POST',
+      '/agents/cashout',
+      cashOutBody,
+    );
+    const cashOutResponse = await cashOutRequest
       .set('Authorization', `Bearer ${token}`)
-      .send({
-        accountId,
-        amount: { currency: 'QZD', value: '100.00' },
-        memo: 'Branch disbursement',
-      })
+      .send(cashOutBody)
       .expect(201);
 
-    const voucherCode = cashOutResponse.body.code as string;
+    const cashOutPayload = getResponseBody<{
+      code?: string;
+      fee?: { value?: string };
+    }>(cashOutResponse);
+    const voucherCode = cashOutPayload.code as string;
     expect(voucherCode).toMatch(/^vch_/);
-    expect(cashOutResponse.body.fee.value).toBe('0.50');
+    expect(cashOutPayload.fee?.value).toBe('0.50');
 
     const postCashOutBalance = await client()
       .get(`/accounts/${accountId}/balance`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
-    const balanceAfterCashOut = Number.parseFloat(postCashOutBalance.body.total.value as string);
+    const postCashOutPayload = getResponseBody<{ total?: { value?: string } }>(postCashOutBalance);
+    const balanceAfterCashOut = Number.parseFloat((postCashOutPayload.total?.value as string) ?? '0');
     expect(balanceAfterCashOut).toBeCloseTo(balanceAfterCashIn - 100.5, 2);
 
-    const redeemResponse = await client()
-      .post(`/agents/vouchers/${voucherCode}/redeem`)
+    const redeemPath = `/agents/vouchers/${voucherCode}/redeem`;
+    const { request: redeemRequest } = applySecurity(
+      client().post(redeemPath),
+      'POST',
+      redeemPath,
+      null,
+    );
+    const redeemResponse = await redeemRequest
       .set('Authorization', `Bearer ${token}`)
       .expect(201);
 
-    expect(redeemResponse.body.status).toBe('redeemed');
-    expect(redeemResponse.body.code).toBe(voucherCode);
+    const redeemPayload = getResponseBody<{ status?: string; code?: string }>(redeemResponse);
+    expect(redeemPayload.status).toBe('redeemed');
+    expect(redeemPayload.code).toBe(voucherCode);
 
     const transactionsResponse = await client()
       .get(`/accounts/${accountId}/transactions`)
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
-    const items = transactionsResponse.body.items as Array<{ type: string; metadata?: Record<string, string> }>;
+    const transactionsPayload = getResponseBody<{ items?: unknown[] }>(transactionsResponse);
+    const items = (transactionsPayload.items as Array<{ type: string; metadata?: Record<string, string> }>) ?? [];
     expect(items[0]?.type).toBe('redemption');
     expect(items[0]?.metadata?.voucherCode).toBe(voucherCode);
     expect(items[1]?.metadata?.feeValue).toBe('0.50');
+  });
+
+  it('rejects replayed requests with the same nonce', async () => {
+    const email = `replay${Date.now()}@example.com`;
+    const password = 'Pass1234!';
+    const fullName = 'Replay User';
+    const client = (): TestClient => supertest(server) as unknown as TestClient;
+
+    const registerBody = { email, password, fullName };
+    const { request: registerRequest } = applySecurity(
+      client().post('/auth/register'),
+      'POST',
+      '/auth/register',
+      registerBody,
+    );
+    const registerResponse = await registerRequest.send(registerBody).expect(201);
+    const registerPayload = getResponseBody<{
+      token?: string;
+      account?: { id?: string };
+    }>(registerResponse);
+
+    const token = registerPayload.token as string;
+    const accountId = registerPayload.account?.id as string;
+
+    const cashInBody = {
+      accountId,
+      amount: { currency: 'QZD', value: '50.00' },
+      memo: 'Replay check',
+    } as const;
+    const overrides: SecurityOverrides = {
+      idempotencyKey: `idem-${randomUUID()}`,
+      nonce: bytesToHex(randomBytes(16)),
+    };
+
+    const { request: firstRequest } = applySecurity(
+      client().post('/agents/cashin'),
+      'POST',
+      '/agents/cashin',
+      cashInBody,
+      overrides,
+    );
+    await firstRequest.set('Authorization', `Bearer ${token}`).send(cashInBody).expect(201);
+
+    const { request: replayRequest } = applySecurity(
+      client().post('/agents/cashin'),
+      'POST',
+      '/agents/cashin',
+      cashInBody,
+      overrides,
+    );
+    const replayResponse = await replayRequest
+      .set('Authorization', `Bearer ${token}`)
+      .send(cashInBody)
+      .expect(409);
+
+    const replayPayload = getResponseBody<{
+      code?: string;
+      message?: { code?: string };
+    }>(replayResponse);
+    expect(replayPayload.message?.code ?? replayPayload.code).toBe('REPLAY_DETECTED');
+  });
+
+  it('returns the same result for idempotent retries', async () => {
+    const email = `idem${Date.now()}@example.com`;
+    const password = 'Pass1234!';
+    const fullName = 'Idem User';
+    const client = (): TestClient => supertest(server) as unknown as TestClient;
+
+    const registerBody = { email, password, fullName };
+    const { request: registerRequest } = applySecurity(
+      client().post('/auth/register'),
+      'POST',
+      '/auth/register',
+      registerBody,
+    );
+    const registerResponse = await registerRequest.send(registerBody).expect(201);
+    const registerPayload = getResponseBody<{
+      token?: string;
+      account?: { id?: string };
+    }>(registerResponse);
+
+    const token = registerPayload.token as string;
+    const accountId = registerPayload.account?.id as string;
+
+    const startingBalanceResponse = await client()
+      .get(`/accounts/${accountId}/balance`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    const startingBalancePayload = getResponseBody<{ total?: { value?: string } }>(startingBalanceResponse);
+    const startingTotal = Number.parseFloat((startingBalancePayload.total?.value as string) ?? '0');
+
+    const cashInBody = {
+      accountId,
+      amount: { currency: 'QZD', value: '75.00' },
+      memo: 'Idempotency test',
+    } as const;
+    const idempotencyKey = `idem-${randomUUID()}`;
+
+    const { request: firstRequest } = applySecurity(
+      client().post('/agents/cashin'),
+      'POST',
+      '/agents/cashin',
+      cashInBody,
+      { idempotencyKey },
+    );
+    const firstResponse = await firstRequest
+      .set('Authorization', `Bearer ${token}`)
+      .send(cashInBody)
+      .expect(201);
+    const firstPayload = getResponseBody<{ id?: string }>(firstResponse);
+
+    const { request: retryRequest } = applySecurity(
+      client().post('/agents/cashin'),
+      'POST',
+      '/agents/cashin',
+      cashInBody,
+      { idempotencyKey },
+    );
+    const retryResponse = await retryRequest
+      .set('Authorization', `Bearer ${token}`)
+      .send(cashInBody)
+      .expect(201);
+    const retryPayload = getResponseBody<{ id?: string }>(retryResponse);
+
+    expect(retryPayload.id).toBe(firstPayload.id);
+
+    const finalBalanceResponse = await client()
+      .get(`/accounts/${accountId}/balance`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    const finalBalancePayload = getResponseBody<{ total?: { value?: string } }>(finalBalanceResponse);
+    const finalTotal = Number.parseFloat((finalBalancePayload.total?.value as string) ?? '0');
+
+    expect(finalTotal - startingTotal).toBeCloseTo(75, 2);
   });
 });

--- a/apps/api/src/impl/accounts.api.ts
+++ b/apps/api/src/impl/accounts.api.ts
@@ -22,6 +22,7 @@ export class AccountsApiImpl extends AccountsApi {
   }
 
   override createAccount(
+    _idempotencyKey: string,
     createAccountRequest: CreateAccountRequest,
     request: Request,
   ): Account | Promise<Account> | Observable<Account> {
@@ -49,6 +50,7 @@ export class AccountsApiImpl extends AccountsApi {
   }
 
   override uploadAccountKyc(
+    _idempotencyKey: string,
     uploadAccountKycRequest: UploadAccountKycRequest,
     request: Request,
   ): Account | Promise<Account> | Observable<Account> {

--- a/apps/api/src/impl/admin.api.ts
+++ b/apps/api/src/impl/admin.api.ts
@@ -22,6 +22,7 @@ export class AdminApiImpl extends AdminApi {
   }
 
   override createIssuanceRequest(
+    _idempotencyKey: string,
     issueRequest: IssueRequest,
     request: Request,
   ): IssuanceRequest | Promise<IssuanceRequest> | Observable<IssuanceRequest> {
@@ -46,9 +47,10 @@ export class AdminApiImpl extends AdminApi {
 
   override signIssuanceRequest(
     id: string,
+    _idempotencyKey: string,
     signIssuanceRequestRequest: SignIssuanceRequestRequest,
     request: Request,
   ): IssuanceRequest | Promise<IssuanceRequest> | Observable<IssuanceRequest> {
-    return this.bank.signIssuanceRequest(id, signIssuanceRequestRequest.validatorId, request);
+    return this.bank.signIssuanceRequest(id, signIssuanceRequestRequest, request);
   }
 }

--- a/apps/api/src/impl/agents.api.ts
+++ b/apps/api/src/impl/agents.api.ts
@@ -21,6 +21,7 @@ export class AgentsApiImpl extends AgentsApi {
   }
 
   override agentCashIn(
+    _idempotencyKey: string,
     agentCashInRequest: AgentCashInRequest,
     request: Request,
   ): Transaction | Promise<Transaction> | Observable<Transaction> {
@@ -28,6 +29,7 @@ export class AgentsApiImpl extends AgentsApi {
   }
 
   override agentCashOut(
+    _idempotencyKey: string,
     agentCashOutRequest: AgentCashOutRequest,
     request: Request,
   ): Voucher | Promise<Voucher> | Observable<Voucher> {
@@ -36,6 +38,7 @@ export class AgentsApiImpl extends AgentsApi {
 
   override redeemVoucher(
     code: string,
+    _idempotencyKey: string,
     request: Request,
   ): Voucher | Promise<Voucher> | Observable<Voucher> {
     return this.bank.redeemVoucher(code, request);

--- a/apps/api/src/impl/auth.api.ts
+++ b/apps/api/src/impl/auth.api.ts
@@ -21,16 +21,18 @@ export class AuthApiImpl extends AuthApi {
   }
 
   override loginUser(
+    _idempotencyKey: string,
     loginUserRequest: LoginUserRequest,
-    _request: Request,
+    request: Request,
   ): LoginUser200Response | Promise<LoginUser200Response> | Observable<LoginUser200Response> {
-    return this.bank.loginUser(loginUserRequest);
+    return this.bank.loginUser(loginUserRequest, request);
   }
 
   override registerUser(
+    _idempotencyKey: string,
     registerUserRequest: RegisterUserRequest,
-    _request: Request,
+    request: Request,
   ): RegisterUser201Response | Promise<RegisterUser201Response> | Observable<RegisterUser201Response> {
-    return this.bank.registerUser(registerUserRequest);
+    return this.bank.registerUser(registerUserRequest, request);
   }
 }

--- a/apps/api/src/impl/ledger.api.ts
+++ b/apps/api/src/impl/ledger.api.ts
@@ -16,6 +16,7 @@ import type {
 @Injectable()
 export class LedgerApiImpl extends LedgerApi {
   override createIssuanceRequest(
+    _idempotencyKey: string,
     _issueRequest: IssueRequest,
     _request: Request,
   ): IssuanceRequest | Promise<IssuanceRequest> | Observable<IssuanceRequest> {
@@ -30,6 +31,7 @@ export class LedgerApiImpl extends LedgerApi {
   }
 
   override issueTokens(
+    _idempotencyKey: string,
     _issueTokensRequest: IssueTokensRequest,
     _request: Request,
   ): Transaction | Promise<Transaction> | Observable<Transaction> {
@@ -43,6 +45,7 @@ export class LedgerApiImpl extends LedgerApi {
   }
 
   override redeemTokens(
+    _idempotencyKey: string,
     redeemRequest: RedeemRequest,
     request: Request,
   ): Transaction | Promise<Transaction> | Observable<Transaction> {

--- a/apps/api/src/impl/remittances.api.ts
+++ b/apps/api/src/impl/remittances.api.ts
@@ -16,6 +16,7 @@ export class RemittancesApiImpl extends RemittancesApi {
   }
 
   override acquireQZDForUSRemittance(
+    _idempotencyKey: string,
     uSRemitAcquireQZDRequest: USRemitAcquireQZDRequest,
     _request: Request,
   ): Transaction | Promise<Transaction> | Observable<Transaction> {

--- a/apps/api/src/impl/sms.api.ts
+++ b/apps/api/src/impl/sms.api.ts
@@ -16,6 +16,7 @@ export class SmsApiImpl extends SmsApi {
   }
 
   override receiveSmsInbound(
+    _idempotencyKey: string,
     smsInboundRequest: SmsInboundRequest,
     request: Request,
   ): SmsInboundResponse | Promise<SmsInboundResponse> | Observable<SmsInboundResponse> {

--- a/apps/api/src/impl/transactions.api.ts
+++ b/apps/api/src/impl/transactions.api.ts
@@ -22,6 +22,7 @@ export class TransactionsApiImpl extends TransactionsApi {
   }
 
   override initiateTransfer(
+    _idempotencyKey: string,
     transferRequest: TransferRequest,
     request: Request,
   ): Transaction | Promise<Transaction> | Observable<Transaction> {
@@ -29,10 +30,11 @@ export class TransactionsApiImpl extends TransactionsApi {
   }
 
   override issueTokens(
+    _idempotencyKey: string,
     issueTokensRequest: IssueTokensRequest,
     request: Request,
   ): Transaction | Promise<Transaction> | Observable<Transaction> {
-    return this.bank.issueFromRequest(issueTokensRequest.requestId, request);
+    return this.bank.issueFromRequest(issueTokensRequest, request);
   }
 
   override listAccountTransactions(
@@ -49,6 +51,7 @@ export class TransactionsApiImpl extends TransactionsApi {
   }
 
   override redeemTokens(
+    _idempotencyKey: string,
     _redeemRequest: RedeemRequest,
     _request: Request,
   ): Transaction | Promise<Transaction> | Observable<Transaction> {

--- a/apps/api/src/request-security.ts
+++ b/apps/api/src/request-security.ts
@@ -1,0 +1,167 @@
+import {
+  BadRequestException,
+  ConflictException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { createHash } from 'node:crypto';
+import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
+import { ed25519 } from '@noble/curves/ed25519';
+
+const IDEMPOTENCY_HEADER = 'idempotency-key';
+const NONCE_HEADER = 'x-qzd-nonce';
+const SIGNATURE_HEADER = 'x-qzd-signature';
+
+const DEV_SIGNING_PRIVATE_KEY_HEX = '0a3c8c97f7925ea37e46f69af43e219b1d09de89ec1a76cf2ce9a9289a392d5a';
+const DEV_SIGNING_PUBLIC_KEY_HEX = bytesToHex(ed25519.getPublicKey(hexToBytes(DEV_SIGNING_PRIVATE_KEY_HEX)));
+const DEV_SIGNING_PUBLIC_KEY_BYTES = hexToBytes(DEV_SIGNING_PUBLIC_KEY_HEX);
+
+export interface SignatureComponents {
+  method: string;
+  path: string;
+  idempotencyKey: string;
+  nonce: string;
+  serializedBody: string;
+}
+
+interface ValidatedMutationContext {
+  scope: string;
+  bodyHash: string;
+}
+
+interface IdempotencyRecord {
+  bodyHash: string;
+  response: unknown;
+}
+
+export function serializeBody(body: unknown): string {
+  if (body === undefined) {
+    return 'null';
+  }
+  return JSON.stringify(body ?? null);
+}
+
+export function createSignaturePayload({
+  method,
+  path,
+  idempotencyKey,
+  nonce,
+  serializedBody,
+}: SignatureComponents): Uint8Array {
+  const canonical = `${method}\n${path}\n${idempotencyKey}\n${nonce}\n${serializedBody}`;
+  return new TextEncoder().encode(canonical);
+}
+
+export const DEV_SIGNING_KEYPAIR = {
+  privateKey: DEV_SIGNING_PRIVATE_KEY_HEX,
+  publicKey: DEV_SIGNING_PUBLIC_KEY_HEX,
+} as const;
+
+export class RequestSecurityManager {
+  private readonly usedNonces = new Set<string>();
+  private readonly idempotencyRecords = new Map<string, IdempotencyRecord>();
+
+  validateMutation(request: Request, body: unknown): ValidatedMutationContext {
+    const method = this.normalizeMethod(request);
+    const path = this.normalizePath(request);
+    const idempotencyKey = this.requireHeader(request, IDEMPOTENCY_HEADER, 'Idempotency-Key header is required');
+    const nonce = this.requireHeader(request, NONCE_HEADER, 'X-QZD-Nonce header is required');
+    const signatureHex = this.requireHeader(request, SIGNATURE_HEADER, 'X-QZD-Signature header is required');
+
+    const signatureBytes = this.decodeHex(signatureHex, 'X-QZD-Signature header must be a hex-encoded string');
+    const serializedBody = serializeBody(body);
+    const payload = createSignaturePayload({ method, path, idempotencyKey, nonce, serializedBody });
+
+    const isValid = ed25519.verify(signatureBytes, payload, DEV_SIGNING_PUBLIC_KEY_BYTES);
+    if (!isValid) {
+      throw new UnauthorizedException({
+        code: 'INVALID_SIGNATURE',
+        message: 'Request signature is invalid.',
+      });
+    }
+
+    if (this.usedNonces.has(nonce)) {
+      throw new ConflictException({
+        code: 'REPLAY_DETECTED',
+        message: 'Nonce has already been used.',
+      });
+    }
+
+    this.usedNonces.add(nonce);
+
+    const scope = `${method}:${path}:${idempotencyKey}`;
+    const bodyHash = this.hash(serializedBody);
+
+    return { scope, bodyHash } satisfies ValidatedMutationContext;
+  }
+
+  applyIdempotency<T>(context: ValidatedMutationContext, factory: () => T): T {
+    const existing = this.idempotencyRecords.get(context.scope);
+    if (existing) {
+      if (existing.bodyHash !== context.bodyHash) {
+        throw new ConflictException({
+          code: 'CONFLICT',
+          message: 'Idempotency key has already been used with a different payload.',
+        });
+      }
+      return this.clone(existing.response) as T;
+    }
+
+    const result = factory();
+    this.idempotencyRecords.set(context.scope, {
+      bodyHash: context.bodyHash,
+      response: this.clone(result),
+    });
+
+    return result;
+  }
+
+  private normalizeMethod(request: Request): string {
+    const candidate = (request as Partial<Request> & { method?: string }).method;
+    return typeof candidate === 'string' && candidate ? candidate.toUpperCase() : 'POST';
+  }
+
+  private normalizePath(request: Request): string {
+    const requestLike = request as Partial<Request> & { originalUrl?: string; url?: string };
+    const original = typeof requestLike.originalUrl === 'string' ? requestLike.originalUrl : requestLike.url ?? '';
+    const [path] = original.split('?');
+    return path || '/';
+  }
+
+  private requireHeader(request: Request, name: string, message: string): string {
+    const headers = this.getHeaders(request);
+    const candidate = headers[name] ?? headers[name.toLowerCase()];
+    const value = Array.isArray(candidate) ? candidate[0] : candidate;
+    if (typeof value !== 'string' || !value.trim()) {
+      throw new BadRequestException(message);
+    }
+    return value.trim();
+  }
+
+  private getHeaders(request: Request): Record<string, unknown> {
+    const requestLike = request as Partial<Request> & { headers?: unknown };
+    const candidate = requestLike.headers;
+    if (candidate && typeof candidate === 'object') {
+      return candidate as Record<string, unknown>;
+    }
+    return {};
+  }
+
+  private decodeHex(value: string, message: string): Uint8Array {
+    if (!/^([0-9a-fA-F]{2})+$/.test(value)) {
+      throw new BadRequestException(message);
+    }
+    return hexToBytes(value);
+  }
+
+  private hash(serialized: string): string {
+    return createHash('sha256').update(serialized).digest('hex');
+  }
+
+  private clone<T>(value: T): T {
+    if (typeof globalThis.structuredClone === 'function') {
+      return structuredClone(value);
+    }
+    return JSON.parse(JSON.stringify(value)) as T;
+  }
+}

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -41,6 +41,8 @@ paths:
         - Auth
       operationId: registerUser
       summary: Register a new customer and provision an associated account.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       requestBody:
         required: true
         content:
@@ -106,6 +108,8 @@ paths:
         - Auth
       operationId: loginUser
       summary: Authenticate an existing user and issue a JWT session token.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       requestBody:
         required: true
         content:
@@ -157,6 +161,8 @@ paths:
         - Accounts
       operationId: createAccount
       summary: Create a new remittance ledger account.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       requestBody:
         required: true
         content:
@@ -211,6 +217,8 @@ paths:
         - Accounts
       operationId: uploadAccountKyc
       summary: Submit KYC evidence for an existing account.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       description: >-
         Upload new metadata, documents, or questionnaire answers to advance an
         account's KYC status. Approved submissions can upgrade the account to
@@ -365,6 +373,8 @@ paths:
         accounts may send up to Q5,000 per day while FULL accounts may send up
         to Q50,000 per day. Requests exceeding these thresholds will be
         rejected with a LIMIT_EXCEEDED error.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       requestBody:
         required: true
         content:
@@ -416,6 +426,8 @@ paths:
         - Ledger
       operationId: issueTokens
       summary: Execute an approved issuance request and credit the beneficiary account.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       requestBody:
         required: true
         content:
@@ -467,6 +479,8 @@ paths:
         - Ledger
       operationId: redeemTokens
       summary: Redeem QZD tokens for fiat settlement.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       requestBody:
         required: true
         content:
@@ -518,6 +532,8 @@ paths:
         - Agents
       operationId: agentCashIn
       summary: Accept cash-in from an agent and credit their QZD balance.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       requestBody:
         required: true
         content:
@@ -566,6 +582,8 @@ paths:
         - Agents
       operationId: agentCashOut
       summary: Convert QZD balance into a voucher code for payout.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       requestBody:
         required: true
         content:
@@ -626,6 +644,7 @@ paths:
           description: Voucher code issued during agent cash-out.
           schema:
             type: string
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       responses:
         '201':
           description: Voucher redeemed successfully.
@@ -668,6 +687,8 @@ paths:
         - Remittances
       operationId: acquireQZDForUSRemittance
       summary: Initiate a US remittance flow that acquires QZD liquidity.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       requestBody:
         required: true
         content:
@@ -885,6 +906,8 @@ paths:
         - Ledger
       operationId: createIssuanceRequest
       summary: Submit a new issuance request to the validator queue.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       requestBody:
         required: true
         content:
@@ -938,6 +961,7 @@ paths:
           schema:
             type: string
           description: Identifier of the issuance request to sign.
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       requestBody:
         required: true
         content:
@@ -1062,6 +1086,8 @@ paths:
         - Sms
       operationId: receiveSmsInbound
       summary: Forward an inbound SMS command for processing.
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKeyHeader'
       requestBody:
         required: true
         content:
@@ -1099,6 +1125,13 @@ components:
       in: path
       required: true
       description: Unique account identifier.
+      schema:
+        type: string
+    IdempotencyKeyHeader:
+      name: Idempotency-Key
+      in: header
+      required: true
+      description: Unique key to guarantee idempotent handling of POST requests.
       schema:
         type: string
   responses:
@@ -1595,6 +1628,8 @@ components:
             - SERVICE_UNAVAILABLE
             - LIMIT_EXCEEDED
             - ACCOUNT_FROZEN
+            - INVALID_SIGNATURE
+            - REPLAY_DETECTED
         message:
           type: string
         details:


### PR DESCRIPTION
## Summary
- add a RequestSecurityManager that verifies Ed25519 signatures, enforces nonce uniqueness, and caches idempotent responses across the in-memory bank service and HTTP handlers
- update the OpenAPI spec and browser apps to require an Idempotency-Key header on POST requests and to expose new INVALID_SIGNATURE and REPLAY_DETECTED error codes
- expand flow integration tests with reusable signing helpers plus new replay and idempotency coverage

## Testing
- pnpm -r lint
- pnpm -r typecheck
- pnpm --filter @qzd/api test

------
https://chatgpt.com/codex/tasks/task_e_68d875e6c9d08330b9144efe7e7aa2de