### PR TITLE
feat(wallet): add sticky app header and navigation

### DIFF
--- a/apps/wallet-web/src/App.css
+++ b/apps/wallet-web/src/App.css
@@ -1,0 +1,319 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f7f9fc;
+  color: #0f172a;
+}
+
+body {
+  margin: 0;
+  background-color: #f7f9fc;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: #f7f9fc;
+}
+
+.app-frame {
+  flex: 1;
+  display: flex;
+  align-items: stretch;
+  min-height: 0;
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid #e2e8f0;
+  padding: 1.5rem 2rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.04);
+}
+
+.app-header__titles {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.app-header__section {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #1d4ed8;
+  background: rgba(29, 78, 216, 0.12);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+}
+
+.app-header__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin: 0;
+}
+
+.app-header__meta dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+  margin-bottom: 0.25rem;
+}
+
+.app-header__meta dd {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #0f172a;
+}
+
+.app-header__status {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: #e0f2fe;
+  color: #0c4a6e;
+  border: 1px solid rgba(14, 116, 144, 0.25);
+}
+
+.side-nav {
+  width: 240px;
+  border-right: 1px solid #e2e8f0;
+  background: #f8fafc;
+  padding: 1.75rem 1.25rem;
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  min-height: calc(100vh - 4.5rem);
+}
+
+.side-nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.side-nav__link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: #1e293b;
+  text-decoration: none;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.75rem;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.side-nav__link:hover {
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.side-nav__link--active {
+  background: #1d4ed8;
+  color: #fff;
+  box-shadow: 0 1px 0 rgba(15, 23, 42, 0.08);
+}
+
+.side-nav__link--disabled {
+  color: #94a3b8;
+  cursor: not-allowed;
+}
+
+.side-nav__link--disabled:hover {
+  background: transparent;
+}
+
+.side-nav__badge {
+  margin-left: auto;
+  font-size: 0.75rem;
+  background: rgba(255, 255, 255, 0.8);
+  color: #1d4ed8;
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+}
+
+.app-content {
+  flex: 1;
+  padding: 2rem 3rem;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.app-content section {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.75rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.app-content h2 {
+  margin-top: 0;
+  margin-bottom: 1.25rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.app-content p {
+  margin-top: 0;
+  color: #475569;
+}
+
+.panel {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.auth-form,
+.account-form,
+.transfer-form,
+.quote-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.auth-form h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: #0f172a;
+}
+
+input,
+select,
+button,
+fieldset {
+  font: inherit;
+}
+
+input,
+select {
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid #cbd5f5;
+  background: #ffffff;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+input:focus,
+select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+}
+
+button {
+  padding: 0.6rem 1rem;
+  border: none;
+  border-radius: 0.6rem;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 120ms ease, box-shadow 120ms ease;
+}
+
+button:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+}
+
+button:not(:disabled):hover {
+  background: #1e40af;
+}
+
+fieldset {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+legend {
+  padding: 0 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.quote-details dl {
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.quote-details dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.quote-details dd {
+  margin: 0;
+  font-weight: 500;
+  color: #0f172a;
+}
+
+@media (max-width: 960px) {
+  .app-frame {
+    flex-direction: column;
+  }
+
+  .side-nav {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid #e2e8f0;
+    position: sticky;
+    top: 4.5rem;
+    min-height: auto;
+    display: flex;
+    overflow-x: auto;
+    padding: 0.75rem 1rem;
+    background: rgba(255, 255, 255, 0.96);
+  }
+
+  .side-nav ul {
+    flex-direction: row;
+  }
+
+  .side-nav__link {
+    flex-direction: column;
+    align-items: center;
+    font-size: 0.85rem;
+  }
+
+  .app-content {
+    padding: 1.5rem;
+  }
+}

--- a/apps/wallet-web/src/App.tsx
+++ b/apps/wallet-web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import type { FormEvent } from 'react';
+import type { FormEvent, MouseEvent } from 'react';
 import {
   AccountsApi,
   AuthApi,
@@ -11,13 +11,69 @@ import {
   type QuoteResponse,
   type Transaction,
 } from '@qzd/sdk-browser';
+import './App.css';
 
 const DEFAULT_API_BASE_URL = 'http://localhost:3000';
 const QUOTE_SCENARIOS = ['DEFAULT', 'SUBSIDIZED', 'TARIFFED'] as const;
+const NAV_SECTIONS = ['auth', 'account', 'balance', 'transactions', 'transfer', 'quote'] as const;
 
 type QuoteScenario = (typeof QUOTE_SCENARIOS)[number];
+type NavigationSection = (typeof NAV_SECTIONS)[number];
+
+type NavItem = {
+  id: NavigationSection;
+  label: string;
+  disabled?: boolean;
+  badge?: string;
+};
 
 type AsyncStatus = 'idle' | 'pending';
+
+const NAV_SECTION_SET = new Set<NavigationSection>(NAV_SECTIONS);
+
+function useHashNavigation(defaultSection: NavigationSection): [NavigationSection, (next: NavigationSection) => void] {
+  const readSection = useCallback((): NavigationSection => {
+    if (typeof window === 'undefined') {
+      return defaultSection;
+    }
+    const raw = window.location.hash.replace(/^#/, '') as NavigationSection;
+    if (NAV_SECTION_SET.has(raw)) {
+      return raw;
+    }
+    return defaultSection;
+  }, [defaultSection]);
+
+  const [active, setActive] = useState<NavigationSection>(() => readSection());
+
+  useEffect(() => {
+    setActive(readSection());
+  }, [readSection]);
+
+  useEffect(() => {
+    const handleHashChange = () => {
+      setActive(readSection());
+    };
+    window.addEventListener('hashchange', handleHashChange);
+    return () => {
+      window.removeEventListener('hashchange', handleHashChange);
+    };
+  }, [readSection]);
+
+  const navigate = useCallback((next: NavigationSection) => {
+    if (typeof window !== 'undefined') {
+      const nextHash = `#${next}`;
+      if (window.location.hash !== nextHash) {
+        window.location.hash = nextHash;
+      } else {
+        setActive(next);
+      }
+    } else {
+      setActive(next);
+    }
+  }, []);
+
+  return [active, navigate];
+}
 
 function createIdempotencyKey(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -310,242 +366,371 @@ export default function App() {
     canUseAccountActions && transferDestinationValid && transferAmountValid && transferStatus !== 'pending';
   const canPreviewQuote = canUseAccountActions && quoteStatus !== 'pending';
 
+  const defaultSection = useMemo<NavigationSection>(() => {
+    if (!token) {
+      return 'auth';
+    }
+    if (!accountLoaded) {
+      return 'account';
+    }
+    return 'balance';
+  }, [accountLoaded, token]);
+
+  const [activeSection, setActiveSection] = useHashNavigation(defaultSection);
+  const transactionsCount = transactions.length;
+
+  const navItems = useMemo<NavItem[]>(() => {
+    if (!token) {
+      return [{ id: 'auth', label: 'Authenticate' }];
+    }
+
+    const items: NavItem[] = [
+      { id: 'account', label: 'Load account' },
+      { id: 'balance', label: 'Balance', disabled: !accountId },
+      {
+        id: 'transactions',
+        label: 'Transactions',
+        disabled: !accountId,
+        badge: accountLoaded && transactionsCount > 0 ? String(transactionsCount) : undefined,
+      },
+      { id: 'transfer', label: 'Send transfer', disabled: !canUseAccountActions },
+      { id: 'quote', label: 'Preview quote', disabled: !canUseAccountActions },
+    ];
+
+    return items;
+  }, [accountId, accountLoaded, canUseAccountActions, token, transactionsCount]);
+
+  useEffect(() => {
+    if (navItems.length === 0) {
+      return;
+    }
+    if (!navItems.some((item) => item.id === activeSection)) {
+      setActiveSection(navItems[0].id);
+    }
+  }, [activeSection, navItems, setActiveSection]);
+
+  const currentSectionLabel = useMemo(() => {
+    return navItems.find((item) => item.id === activeSection)?.label ?? navItems[0]?.label ?? 'Wallet';
+  }, [activeSection, navItems]);
+
   return (
-    <main className="app-shell">
-      <header>
-        <h1>QZD Wallet</h1>
-        <p>
-          API base URL: <code>{configuredBaseUrl}</code>
-        </p>
-        {token ? <p role="status">Session active.</p> : <p role="status">Not signed in.</p>}
-        {statusMessage && (
-          <p className="status" aria-live="polite">
-            {statusMessage}
-          </p>
-        )}
-      </header>
+    <div className="app-shell">
+      <AppHeader
+        baseUrl={configuredBaseUrl}
+        sessionActive={Boolean(token)}
+        statusMessage={statusMessage}
+        currentSectionLabel={currentSectionLabel}
+      />
 
-      {!token && (
-        <section aria-labelledby="auth-section">
-          <h2 id="auth-section">Register / Log in</h2>
-          <div className="panel">
-            <form onSubmit={handleRegister} className="auth-form">
-              <h3>Register</h3>
-              <label>
-                Email
-                <input name="register-email" type="email" autoComplete="email" required />
-              </label>
-              <label>
-                Password
-                <input name="register-password" type="password" autoComplete="new-password" required />
-              </label>
-              <label>
-                Full name
-                <input name="register-name" type="text" autoComplete="name" required />
-              </label>
-              <button type="submit">Register</button>
-            </form>
+      <div className="app-frame">
+        <SideNav items={navItems} activeSection={activeSection} onNavigate={setActiveSection} />
 
-            <form onSubmit={handleLogin} className="auth-form">
-              <h3>Log in</h3>
-              <label>
-                Email
-                <input name="login-email" type="email" autoComplete="email" required />
-              </label>
-              <label>
-                Password
-                <input name="login-password" type="password" autoComplete="current-password" required />
-              </label>
-              <button type="submit">Sign in</button>
-            </form>
-          </div>
-        </section>
-      )}
-
-      {token && (
-        <section aria-labelledby="account-section">
-          <h2 id="account-section">Load account</h2>
-          <form onSubmit={handleAccountSelection} className="account-form">
-            <label>
-              Account ID
-              <input
-                value={accountIdInput}
-                onChange={(event) => setAccountIdInput(event.target.value)}
-                placeholder="acct_..."
-              />
-            </label>
-            <button type="submit">Load account</button>
-          </form>
-        </section>
-      )}
-
-      {token && (
-        <section aria-labelledby="balance-section">
-          <h2 id="balance-section">Balance</h2>
-          {!accountId && <p>Enter an account ID and load it to view balances.</p>}
-          {accountId && accountStatus === 'pending' && <p aria-live="polite">Loading account data…</p>}
-          {accountId && accountStatus === 'idle' && !accountLoaded && (
-            <p>Unable to load account details. Verify the account ID.</p>
-          )}
-          {accountLoaded && balance && (
-            <dl>
-              <div>
-                <dt>Available</dt>
-                <dd>{formatAmount(balance.available)}</dd>
-              </div>
-              <div>
-                <dt>Total</dt>
-                <dd>{formatAmount(balance.total)}</dd>
-              </div>
-              <div>
-                <dt>Updated</dt>
-                <dd>{formatTimestamp(balance.updatedAt)}</dd>
-              </div>
-            </dl>
-          )}
-        </section>
-      )}
-
-      {token && (
-        <section aria-labelledby="transactions-section">
-          <h2 id="transactions-section">Transactions</h2>
-          {!accountLoaded && <p>Load an account to view recent transactions.</p>}
-          {accountLoaded && transactions.length === 0 ? (
-            <p>No transactions to display.</p>
-          ) : null}
-          {accountLoaded && transactions.length > 0 && (
-            <ul>
-              {transactions.map((transaction) => (
-                <li key={transaction.id}>
-                  <strong>{transaction.type}</strong> · {formatAmount(transaction.amount)} · {transaction.status}{' '}
-                  · {formatTimestamp(transaction.createdAt)}
-                  {transaction.counterpartyAccountId && (
-                    <>
-                      {' '}
-                      · Counterparty: {transaction.counterpartyAccountId}
-                    </>
-                  )}
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
-      )}
-
-      {token && (
-        <section aria-labelledby="transfer-section">
-          <h2 id="transfer-section">Send transfer</h2>
-          {!accountLoaded && <p>Load an account to send funds.</p>}
-          {accountLoaded && (
-            <form onSubmit={handleSendTransfer} className="transfer-form">
-              <label>
-                Destination account
-                <input
-                  value={transferDestination}
-                  onChange={(event) => setTransferDestination(event.target.value)}
-                  required
-                  disabled={!canUseAccountActions || transferStatus === 'pending'}
-                />
-              </label>
-              <label>
-                Currency
-                <input
-                  value={transferCurrency}
-                  onChange={(event) => setTransferCurrency(event.target.value)}
-                  disabled={!canUseAccountActions || transferStatus === 'pending'}
-                />
-              </label>
-              <label>
-                Amount
-                <input
-                  value={transferAmount}
-                  onChange={(event) => setTransferAmount(event.target.value)}
-                  required
-                  disabled={!canUseAccountActions || transferStatus === 'pending'}
-                />
-              </label>
-              <label>
-                Memo
-                <input
-                  value={transferMemo}
-                  onChange={(event) => setTransferMemo(event.target.value)}
-                  placeholder="Optional"
-                  disabled={!canUseAccountActions || transferStatus === 'pending'}
-                />
-              </label>
-              <button type="submit" disabled={!canSubmitTransfer}>
-                {transferStatus === 'pending' ? 'Sending…' : 'Send'}
-              </button>
-            </form>
-          )}
-        </section>
-      )}
-
-      {token && (
-        <section aria-labelledby="quote-section">
-          <h2 id="quote-section">Preview quote</h2>
-          {!accountLoaded && <p>Load an account to preview quotes.</p>}
-          {accountLoaded && (
-            <form onSubmit={handlePreviewQuote} className="quote-form">
-              <label>
-                USD amount
-                <input
-                  value={quoteAmount}
-                  onChange={(event) => setQuoteAmount(event.target.value)}
-                  required
-                  disabled={!canUseAccountActions || quoteStatus === 'pending'}
-                />
-              </label>
-              <fieldset disabled={!canUseAccountActions || quoteStatus === 'pending'}>
-                <legend>Scenario</legend>
-                {QUOTE_SCENARIOS.map((scenario) => (
-                  <label key={scenario}>
-                    <input
-                      type="radio"
-                      name="quote-scenario"
-                      value={scenario}
-                      checked={quoteScenario === scenario}
-                      onChange={() => setQuoteScenario(scenario)}
-                    />
-                    {scenario}
+        <main className="app-content">
+          {!token && (
+            <section id="auth" aria-labelledby="auth-section">
+              <h2 id="auth-section">Register / Log in</h2>
+              <div className="panel">
+                <form onSubmit={handleRegister} className="auth-form">
+                  <h3>Register</h3>
+                  <label>
+                    Email
+                    <input name="register-email" type="email" autoComplete="email" required />
                   </label>
-                ))}
-              </fieldset>
-              <button type="submit" disabled={!canPreviewQuote}>
-                {quoteStatus === 'pending' ? 'Fetching…' : 'Preview quote'}
-              </button>
-            </form>
+                  <label>
+                    Password
+                    <input name="register-password" type="password" autoComplete="new-password" required />
+                  </label>
+                  <label>
+                    Full name
+                    <input name="register-name" type="text" autoComplete="name" required />
+                  </label>
+                  <button type="submit">Register</button>
+                </form>
+
+                <form onSubmit={handleLogin} className="auth-form">
+                  <h3>Log in</h3>
+                  <label>
+                    Email
+                    <input name="login-email" type="email" autoComplete="email" required />
+                  </label>
+                  <label>
+                    Password
+                    <input name="login-password" type="password" autoComplete="current-password" required />
+                  </label>
+                  <button type="submit">Sign in</button>
+                </form>
+              </div>
+            </section>
           )}
 
-          {accountLoaded && quote && (
-            <div className="quote-details">
-              <h3>Quote details</h3>
-              <dl>
-                <div>
-                  <dt>Quote ID</dt>
-                  <dd>{quote.quoteId}</dd>
-                </div>
-                <div>
-                  <dt>Sell amount</dt>
-                  <dd>{formatAmount(quote.sellAmount)}</dd>
-                </div>
-                <div>
-                  <dt>Buy amount</dt>
-                  <dd>{formatAmount(quote.buyAmount)}</dd>
-                </div>
-                <div>
-                  <dt>Rate</dt>
-                  <dd>{quote.rate}</dd>
-                </div>
-                <div>
-                  <dt>Expires</dt>
-                  <dd>{formatTimestamp(quote.expiresAt)}</dd>
-                </div>
-              </dl>
-            </div>
+          {token && (
+            <section id="account" aria-labelledby="account-section">
+              <h2 id="account-section">Load account</h2>
+              <form onSubmit={handleAccountSelection} className="account-form">
+                <label>
+                  Account ID
+                  <input
+                    value={accountIdInput}
+                    onChange={(event) => setAccountIdInput(event.target.value)}
+                    placeholder="acct_..."
+                  />
+                </label>
+                <button type="submit">Load account</button>
+              </form>
+            </section>
           )}
-        </section>
-      )}
-    </main>
+
+          {token && (
+            <section id="balance" aria-labelledby="balance-section">
+              <h2 id="balance-section">Balance</h2>
+              {!accountId && <p>Enter an account ID and load it to view balances.</p>}
+              {accountId && accountStatus === 'pending' && <p aria-live="polite">Loading account data…</p>}
+              {accountId && accountStatus === 'idle' && !accountLoaded && (
+                <p>Unable to load account details. Verify the account ID.</p>
+              )}
+              {accountLoaded && balance && (
+                <dl>
+                  <div>
+                    <dt>Available</dt>
+                    <dd>{formatAmount(balance.available)}</dd>
+                  </div>
+                  <div>
+                    <dt>Total</dt>
+                    <dd>{formatAmount(balance.total)}</dd>
+                  </div>
+                  <div>
+                    <dt>Updated</dt>
+                    <dd>{formatTimestamp(balance.updatedAt)}</dd>
+                  </div>
+                </dl>
+              )}
+            </section>
+          )}
+
+          {token && (
+            <section id="transactions" aria-labelledby="transactions-section">
+              <h2 id="transactions-section">Transactions</h2>
+              {!accountLoaded && <p>Load an account to view recent transactions.</p>}
+              {accountLoaded && transactions.length === 0 ? (
+                <p>No transactions to display.</p>
+              ) : null}
+              {accountLoaded && transactions.length > 0 && (
+                <ul>
+                  {transactions.map((transaction) => (
+                    <li key={transaction.id}>
+                      <strong>{transaction.type}</strong> · {formatAmount(transaction.amount)} · {transaction.status}{' '}
+                      · {formatTimestamp(transaction.createdAt)}
+                      {transaction.counterpartyAccountId && (
+                        <>
+                          {' '}
+                          · Counterparty: {transaction.counterpartyAccountId}
+                        </>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          )}
+
+          {token && (
+            <section id="transfer" aria-labelledby="transfer-section">
+              <h2 id="transfer-section">Send transfer</h2>
+              {!accountLoaded && <p>Load an account to send funds.</p>}
+              {accountLoaded && (
+                <form onSubmit={handleSendTransfer} className="transfer-form">
+                  <label>
+                    Destination account
+                    <input
+                      value={transferDestination}
+                      onChange={(event) => setTransferDestination(event.target.value)}
+                      required
+                      disabled={!canUseAccountActions || transferStatus === 'pending'}
+                    />
+                  </label>
+                  <label>
+                    Currency
+                    <input
+                      value={transferCurrency}
+                      onChange={(event) => setTransferCurrency(event.target.value)}
+                      disabled={!canUseAccountActions || transferStatus === 'pending'}
+                    />
+                  </label>
+                  <label>
+                    Amount
+                    <input
+                      value={transferAmount}
+                      onChange={(event) => setTransferAmount(event.target.value)}
+                      required
+                      disabled={!canUseAccountActions || transferStatus === 'pending'}
+                    />
+                  </label>
+                  <label>
+                    Memo
+                    <input
+                      value={transferMemo}
+                      onChange={(event) => setTransferMemo(event.target.value)}
+                      placeholder="Optional"
+                      disabled={!canUseAccountActions || transferStatus === 'pending'}
+                    />
+                  </label>
+                  <button type="submit" disabled={!canSubmitTransfer}>
+                    {transferStatus === 'pending' ? 'Sending…' : 'Send'}
+                  </button>
+                </form>
+              )}
+            </section>
+          )}
+
+          {token && (
+            <section id="quote" aria-labelledby="quote-section">
+              <h2 id="quote-section">Preview quote</h2>
+              {!accountLoaded && <p>Load an account to preview quotes.</p>}
+              {accountLoaded && (
+                <form onSubmit={handlePreviewQuote} className="quote-form">
+                  <label>
+                    USD amount
+                    <input
+                      value={quoteAmount}
+                      onChange={(event) => setQuoteAmount(event.target.value)}
+                      required
+                      disabled={!canUseAccountActions || quoteStatus === 'pending'}
+                    />
+                  </label>
+                  <fieldset disabled={!canUseAccountActions || quoteStatus === 'pending'}>
+                    <legend>Scenario</legend>
+                    {QUOTE_SCENARIOS.map((scenario) => (
+                      <label key={scenario}>
+                        <input
+                          type="radio"
+                          name="quote-scenario"
+                          value={scenario}
+                          checked={quoteScenario === scenario}
+                          onChange={() => setQuoteScenario(scenario)}
+                        />
+                        {scenario}
+                      </label>
+                    ))}
+                  </fieldset>
+                  <button type="submit" disabled={!canPreviewQuote}>
+                    {quoteStatus === 'pending' ? 'Fetching…' : 'Preview quote'}
+                  </button>
+                </form>
+              )}
+
+              {accountLoaded && quote && (
+                <div className="quote-details">
+                  <h3>Quote details</h3>
+                  <dl>
+                    <div>
+                      <dt>Quote ID</dt>
+                      <dd>{quote.quoteId}</dd>
+                    </div>
+                    <div>
+                      <dt>Sell amount</dt>
+                      <dd>{formatAmount(quote.sellAmount)}</dd>
+                    </div>
+                    <div>
+                      <dt>Buy amount</dt>
+                      <dd>{formatAmount(quote.buyAmount)}</dd>
+                    </div>
+                    <div>
+                      <dt>Rate</dt>
+                      <dd>{quote.rate}</dd>
+                    </div>
+                    <div>
+                      <dt>Expires</dt>
+                      <dd>{formatTimestamp(quote.expiresAt)}</dd>
+                    </div>
+                  </dl>
+                </div>
+              )}
+            </section>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+type AppHeaderProps = {
+  baseUrl: string;
+  sessionActive: boolean;
+  statusMessage: string | null;
+  currentSectionLabel: string;
+};
+
+function AppHeader({ baseUrl, sessionActive, statusMessage, currentSectionLabel }: AppHeaderProps) {
+  return (
+    <header className="app-header">
+      <div className="app-header__titles">
+        <h1>QZD Wallet</h1>
+        <p className="app-header__section" aria-live="polite">
+          {currentSectionLabel}
+        </p>
+      </div>
+      <dl className="app-header__meta">
+        <div>
+          <dt>API base</dt>
+          <dd>
+            <code>{baseUrl}</code>
+          </dd>
+        </div>
+        <div>
+          <dt>Session</dt>
+          <dd>{sessionActive ? 'Active' : 'Not signed in'}</dd>
+        </div>
+      </dl>
+      {statusMessage ? (
+        <p className="app-header__status" role="status" aria-live="polite">
+          {statusMessage}
+        </p>
+      ) : null}
+    </header>
+  );
+}
+
+type SideNavProps = {
+  items: NavItem[];
+  activeSection: NavigationSection;
+  onNavigate: (next: NavigationSection) => void;
+};
+
+function SideNav({ items, activeSection, onNavigate }: SideNavProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <nav className="side-nav" aria-label="Wallet navigation">
+      <ul>
+        {items.map((item) => {
+          const isActive = item.id === activeSection;
+          const disabled = item.disabled ?? false;
+          const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+            if (disabled) {
+              event.preventDefault();
+              return;
+            }
+            onNavigate(item.id);
+          };
+
+          return (
+            <li key={item.id}>
+              <a
+                href={`#${item.id}`}
+                onClick={handleClick}
+                className={`side-nav__link${isActive ? ' side-nav__link--active' : ''}${disabled ? ' side-nav__link--disabled' : ''}`}
+                aria-current={isActive ? 'page' : undefined}
+                aria-disabled={disabled}
+              >
+                <span>{item.label}</span>
+                {item.badge ? <span className="side-nav__badge">{item.badge}</span> : null}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,8 @@ importers:
         specifier: ^1.3.1
         version: 1.6.1(@types/node@20.19.17)
 
+  apps/sms-sim: {}
+
   apps/wallet-web:
     dependencies:
       '@qzd/sdk-browser':


### PR DESCRIPTION
## Summary
- introduce a reusable wallet app header with navigation state awareness
- add side navigation wiring and hash routing so each page uses the shared shell
- style the shell with a sticky header and responsive layout to prevent overlap

## Testing
- pnpm --filter @qzd/wallet-web test
- pnpm --filter @qzd/wallet-web lint

------
https://chatgpt.com/codex/tasks/task_e_68dab71f215c83309a3a2eef917b0fa9