### PR TITLE
feat: add merchant POS QR invoice app

### DIFF
--- a/apps/merchant-pos/index.html
+++ b/apps/merchant-pos/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>QZD Merchant POS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/merchant-pos/package.json
+++ b/apps/merchant-pos/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@qzd/merchant-pos",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@qzd/sdk-browser": "workspace:*",
+    "jspdf": "^2.5.2",
+    "qrcode": "^1.5.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.3.0",
+    "@testing-library/react": "^14.1.2",
+    "@types/qrcode": "^1.5.5",
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.0",
+    "jsdom": "^24.0.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.4",
+    "vitest": "^1.3.1"
+  }
+}

--- a/apps/merchant-pos/src/App.tsx
+++ b/apps/merchant-pos/src/App.tsx
@@ -1,0 +1,561 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { FormEvent } from 'react';
+import { jsPDF } from 'jspdf';
+import QRCode from 'qrcode';
+import {
+  AuthApi,
+  Configuration,
+  TransactionsApi,
+  type Transaction,
+} from '@qzd/sdk-browser';
+import {
+  buildPaymentMatch,
+  createInvoice,
+  encodeInvoicePayload,
+  transactionMatchesInvoice,
+  type Invoice,
+} from './lib/invoices';
+
+const DEFAULT_API_BASE_URL = 'http://localhost:3000';
+const POLL_INTERVAL_MS = 5000;
+
+type AsyncStatus = 'idle' | 'pending';
+
+type InvoiceFormState = {
+  amountValue: string;
+  currency: string;
+  description: string;
+  customerName: string;
+};
+
+function sanitizeBaseUrl(value: string | undefined): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return DEFAULT_API_BASE_URL;
+  }
+  return trimmed.replace(/\/+$/, '');
+}
+
+function formatAmount(invoice: Invoice): string {
+  return `${invoice.amount.value} ${invoice.amount.currency}`;
+}
+
+function formatTimestamp(value: string | Date | undefined): string {
+  if (!value) {
+    return '—';
+  }
+
+  const asDate = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(asDate.getTime())) {
+    return String(value);
+  }
+
+  return asDate.toLocaleString();
+}
+
+function createIdempotencyKey(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `idem-${crypto.randomUUID()}`;
+  }
+  const randomSuffix = Math.random().toString(16).slice(2);
+  return `idem-${Date.now()}-${randomSuffix}`;
+}
+
+export default function App(): JSX.Element {
+  const configuredBaseUrl = sanitizeBaseUrl(import.meta.env.VITE_API_BASE_URL as string | undefined);
+  const [token, setToken] = useState<string | null>(null);
+  const [accountIdInput, setAccountIdInput] = useState('');
+  const [accountId, setAccountId] = useState('');
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [authStatus, setAuthStatus] = useState<AsyncStatus>('idle');
+  const [invoiceStatus, setInvoiceStatus] = useState<AsyncStatus>('idle');
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
+  const [form, setForm] = useState<InvoiceFormState>({
+    amountValue: '25.00',
+    currency: 'QZD',
+    description: '',
+    customerName: '',
+  });
+
+  const invoicesRef = useRef<Invoice[]>([]);
+
+  useEffect(() => {
+    invoicesRef.current = invoices;
+  }, [invoices]);
+
+  const configuration = useMemo(
+    () =>
+      new Configuration({
+        basePath: configuredBaseUrl,
+        accessToken: token ? async () => token : undefined,
+      }),
+    [configuredBaseUrl, token],
+  );
+
+  const authApi = useMemo(() => new AuthApi(configuration), [configuration]);
+  const transactionsApi = useMemo(() => new TransactionsApi(configuration), [configuration]);
+
+  const resetStatus = useCallback((message: string | null) => {
+    setStatusMessage(message);
+  }, []);
+
+  const handleRegister = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (authStatus === 'pending') {
+        return;
+      }
+
+      const formData = new FormData(event.currentTarget);
+      const fullName = String(formData.get('register-name') ?? '').trim();
+      const email = String(formData.get('register-email') ?? '').trim();
+      const password = String(formData.get('register-password') ?? '').trim();
+
+      if (!fullName || !email || !password) {
+        resetStatus('Name, email, and password are required to register.');
+        return;
+      }
+
+      setAuthStatus('pending');
+      try {
+        const response = await authApi.registerUser({
+          idempotencyKey: createIdempotencyKey(),
+          registerUserRequest: { email, password, fullName },
+        });
+
+        const sessionToken = response.token ?? null;
+        const newAccountId = response.account?.id ?? '';
+
+        setToken(sessionToken);
+        setAccountIdInput(newAccountId);
+        setAccountId(newAccountId);
+        resetStatus(
+          sessionToken
+            ? 'Registration successful. You are now signed in.'
+            : 'Registration successful. Please log in.',
+        );
+      } catch (error) {
+        console.error('Registration failed', error);
+        resetStatus(error instanceof Error ? error.message : 'Registration failed.');
+      } finally {
+        setAuthStatus('idle');
+      }
+    },
+    [authApi, authStatus, resetStatus],
+  );
+
+  const handleLogin = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (authStatus === 'pending') {
+        return;
+      }
+
+      const formData = new FormData(event.currentTarget);
+      const email = String(formData.get('login-email') ?? '').trim();
+      const password = String(formData.get('login-password') ?? '').trim();
+
+      if (!email || !password) {
+        resetStatus('Email and password are required to sign in.');
+        return;
+      }
+
+      setAuthStatus('pending');
+      try {
+        const response = await authApi.loginUser({
+          idempotencyKey: createIdempotencyKey(),
+          loginUserRequest: { email, password },
+        });
+        const sessionToken = response.token ?? null;
+        if (!sessionToken) {
+          resetStatus('Login response did not include a session token.');
+          return;
+        }
+
+        setToken(sessionToken);
+        resetStatus('Logged in successfully.');
+      } catch (error) {
+        console.error('Login failed', error);
+        resetStatus(error instanceof Error ? error.message : 'Login failed.');
+      } finally {
+        setAuthStatus('idle');
+      }
+    },
+    [authApi, authStatus, resetStatus],
+  );
+
+  const handleAccountSelection = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const nextId = accountIdInput.trim();
+      setAccountId(nextId);
+      if (nextId) {
+        setInvoices((current) => current.filter((invoice) => invoice.accountId === nextId));
+      } else {
+        setInvoices([]);
+      }
+      if (!nextId) {
+        resetStatus('Enter an account ID to monitor invoices.');
+        return;
+      }
+      resetStatus(null);
+    },
+    [accountIdInput, resetStatus],
+  );
+
+  const handleInvoiceFieldChange = useCallback(<Field extends keyof InvoiceFormState>(field: Field, value: string) => {
+    setForm((current) => ({ ...current, [field]: value }));
+  }, []);
+
+  const handleCreateInvoice = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!token || !accountId) {
+        resetStatus('Sign in and select an account before creating invoices.');
+        return;
+      }
+
+      setInvoiceStatus('pending');
+      try {
+        const invoice = createInvoice({
+          accountId,
+          amountValue: form.amountValue,
+          currency: form.currency,
+          description: form.description,
+          customerName: form.customerName,
+        });
+
+        const payload = encodeInvoicePayload(invoice);
+        const qrCodeDataUrl = await QRCode.toDataURL(payload, { width: 256, margin: 1 });
+
+        const invoiceWithQr: Invoice = { ...invoice, qrCodeDataUrl };
+
+        setInvoices((current) => [invoiceWithQr, ...current]);
+        resetStatus('Invoice generated. Share the QR code and memo with the customer.');
+      } catch (error) {
+        console.error('Failed to create invoice', error);
+        resetStatus(error instanceof Error ? error.message : 'Unable to create invoice.');
+      } finally {
+        setInvoiceStatus('idle');
+      }
+    },
+    [accountId, form, resetStatus, token],
+  );
+
+  const pollForPayments = useCallback(
+    async (signal: AbortSignal) => {
+      if (!token || !accountId) {
+        return;
+      }
+
+      const pendingInvoices = invoicesRef.current.filter((invoice) => invoice.status === 'pending');
+      if (pendingInvoices.length === 0) {
+        return;
+      }
+
+      try {
+        const response = await transactionsApi.listAccountTransactions({ id: accountId, limit: 50 });
+        const transactions = response.items ?? [];
+
+        const matches: Array<{ invoice: Invoice; transaction: Transaction }> = [];
+        for (const invoice of pendingInvoices) {
+          const match = transactions.find((transaction) => transactionMatchesInvoice(transaction, invoice));
+          if (match) {
+            matches.push({ invoice, transaction: match });
+          }
+        }
+
+        if (matches.length === 0) {
+          return;
+        }
+
+        setInvoices((current) =>
+          current.map((invoice) => {
+            const found = matches.find((item) => item.invoice.id === invoice.id);
+            if (!found) {
+              return invoice;
+            }
+
+            const payment = buildPaymentMatch(found.transaction, invoice);
+            return {
+              ...invoice,
+              status: 'paid',
+              paidTransactionId: payment.transactionId,
+              paidAt: payment.paidAt,
+            } satisfies Invoice;
+          }),
+        );
+        resetStatus('Payment received. Invoice marked as paid.');
+      } catch (error) {
+        if (signal.aborted) {
+          return;
+        }
+        console.error('Failed to poll transactions', error);
+      }
+    },
+    [accountId, resetStatus, token, transactionsApi],
+  );
+
+  useEffect(() => {
+    if (!token || !accountId) {
+      return;
+    }
+
+    const controller = new AbortController();
+    let cancelled = false;
+
+    const tick = async () => {
+      if (cancelled) {
+        return;
+      }
+      await pollForPayments(controller.signal);
+    };
+
+    const interval = window.setInterval(() => {
+      void tick();
+    }, POLL_INTERVAL_MS);
+
+    void tick();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      window.clearInterval(interval);
+    };
+  }, [accountId, pollForPayments, token]);
+
+  const handleCopyMemo = useCallback(
+    async (memo: string) => {
+      try {
+        if (!('clipboard' in navigator) || typeof navigator.clipboard?.writeText !== 'function') {
+          throw new Error('Clipboard API unavailable');
+        }
+        await navigator.clipboard.writeText(memo);
+        resetStatus('Invoice memo copied to clipboard.');
+      } catch (error) {
+        console.error('Failed to copy memo', error);
+        resetStatus('Unable to access the clipboard. Copy manually.');
+      }
+    },
+    [resetStatus],
+  );
+
+  const handleExportReceipt = useCallback((invoice: Invoice) => {
+    if (invoice.status !== 'paid') {
+      return;
+    }
+
+    const doc = new jsPDF();
+    const startY = 20;
+
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(18);
+    doc.text('QZD Payment Receipt', 14, startY);
+
+    doc.setFontSize(12);
+    doc.setFont('helvetica', 'normal');
+    doc.text(`Invoice reference: ${invoice.reference}`, 14, startY + 12);
+    doc.text(`Amount: ${formatAmount(invoice)}`, 14, startY + 20);
+    doc.text(`Customer: ${invoice.customerName ?? '—'}`, 14, startY + 28);
+    doc.text(`Description: ${invoice.description ?? '—'}`, 14, startY + 36);
+    doc.text(`Paid at: ${formatTimestamp(invoice.paidAt)}`, 14, startY + 44);
+    doc.text(`Transaction ID: ${invoice.paidTransactionId ?? '—'}`, 14, startY + 52);
+
+    doc.setFont('helvetica', 'italic');
+    doc.text('Generated by QZD Merchant POS', 14, startY + 64);
+
+    doc.save(`qzd-receipt-${invoice.reference}.pdf`);
+  }, []);
+
+  const canManageInvoices = Boolean(token && accountId);
+
+  return (
+    <main>
+      <header>
+        <h1>QZD Merchant POS</h1>
+        <p>Generate QR invoices, confirm wallet payments, and export receipts.</p>
+      </header>
+
+      {statusMessage && <p className="status-message">{statusMessage}</p>}
+
+      <section aria-labelledby="auth-section">
+        <h2 id="auth-section">Merchant access</h2>
+        <div className="auth-layout">
+          <form onSubmit={handleRegister} className="auth-form">
+            <h3>Create merchant</h3>
+            <label>
+              Full name
+              <input name="register-name" placeholder="Ada Lovelace" disabled={authStatus === 'pending'} required />
+            </label>
+            <label>
+              Email
+              <input
+                type="email"
+                name="register-email"
+                placeholder="merchant@example.com"
+                disabled={authStatus === 'pending'}
+                required
+              />
+            </label>
+            <label>
+              Password
+              <input type="password" name="register-password" disabled={authStatus === 'pending'} required />
+            </label>
+            <button type="submit" disabled={authStatus === 'pending'}>
+              {authStatus === 'pending' ? 'Submitting…' : 'Register & sign in'}
+            </button>
+          </form>
+
+          <form onSubmit={handleLogin} className="auth-form">
+            <h3>Sign in</h3>
+            <label>
+              Email
+              <input type="email" name="login-email" disabled={authStatus === 'pending'} required />
+            </label>
+            <label>
+              Password
+              <input type="password" name="login-password" disabled={authStatus === 'pending'} required />
+            </label>
+            <button type="submit" disabled={authStatus === 'pending'}>
+              {authStatus === 'pending' ? 'Verifying…' : 'Sign in'}
+            </button>
+          </form>
+        </div>
+      </section>
+
+      <section aria-labelledby="account-section">
+        <h2 id="account-section">Settlement account</h2>
+        <form onSubmit={handleAccountSelection}>
+          <label>
+            Account ID
+            <input
+              value={accountIdInput}
+              onChange={(event) => setAccountIdInput(event.target.value)}
+              placeholder="acc_12345"
+            />
+          </label>
+          <button type="submit">Monitor account</button>
+        </form>
+        <p>
+          API: <code>{configuredBaseUrl}</code>
+        </p>
+      </section>
+
+      <section aria-labelledby="invoice-section">
+        <h2 id="invoice-section">Invoice details</h2>
+        <form onSubmit={handleCreateInvoice}>
+          <label>
+            Amount
+            <input
+              value={form.amountValue}
+              onChange={(event) => handleInvoiceFieldChange('amountValue', event.target.value)}
+              placeholder="25.00"
+              required
+              disabled={!canManageInvoices || invoiceStatus === 'pending'}
+            />
+          </label>
+          <label>
+            Currency
+            <input
+              value={form.currency}
+              onChange={(event) => handleInvoiceFieldChange('currency', event.target.value)}
+              disabled={!canManageInvoices || invoiceStatus === 'pending'}
+            />
+          </label>
+          <label>
+            Customer name
+            <input
+              value={form.customerName}
+              onChange={(event) => handleInvoiceFieldChange('customerName', event.target.value)}
+              placeholder="Optional"
+              disabled={!canManageInvoices || invoiceStatus === 'pending'}
+            />
+          </label>
+          <label>
+            Description
+            <textarea
+              value={form.description}
+              onChange={(event) => handleInvoiceFieldChange('description', event.target.value)}
+              placeholder="Notes for the receipt"
+              disabled={!canManageInvoices || invoiceStatus === 'pending'}
+            />
+          </label>
+          <button type="submit" disabled={!canManageInvoices || invoiceStatus === 'pending'}>
+            {invoiceStatus === 'pending' ? 'Generating…' : 'Create invoice'}
+          </button>
+        </form>
+        <p>
+          Share the QR code and invoice memo with the customer. Wallet users should paste the memo into the transfer form so the
+          POS can auto-confirm payment.
+        </p>
+      </section>
+
+      <section aria-labelledby="history-section">
+        <h2 id="history-section">Invoice history</h2>
+        {invoices.length === 0 ? (
+          <p>No invoices yet. Create one to get started.</p>
+        ) : (
+          <ul className="invoice-list">
+            {invoices.map((invoice) => (
+              <li key={invoice.id} className="invoice-card">
+                <header>
+                  <h3>{invoice.reference}</h3>
+                  <span className="invoice-status" data-status={invoice.status}>
+                    {invoice.status === 'paid' ? 'Paid' : 'Awaiting payment'}
+                  </span>
+                </header>
+
+                <div className="qr-wrapper">
+                  {invoice.qrCodeDataUrl ? (
+                    <img src={invoice.qrCodeDataUrl} alt={`QR code for invoice ${invoice.reference}`} />
+                  ) : (
+                    <p>QR code unavailable.</p>
+                  )}
+                  <textarea readOnly value={invoice.memo} />
+                </div>
+
+                <dl className="details-grid">
+                  <div>
+                    <dt>Amount</dt>
+                    <dd>{formatAmount(invoice)}</dd>
+                  </div>
+                  <div>
+                    <dt>Customer</dt>
+                    <dd>{invoice.customerName ?? '—'}</dd>
+                  </div>
+                  <div>
+                    <dt>Description</dt>
+                    <dd>{invoice.description ?? '—'}</dd>
+                  </div>
+                  <div>
+                    <dt>Created</dt>
+                    <dd>{formatTimestamp(invoice.createdAt)}</dd>
+                  </div>
+                  <div>
+                    <dt>Paid at</dt>
+                    <dd>{formatTimestamp(invoice.paidAt)}</dd>
+                  </div>
+                  <div>
+                    <dt>Transaction</dt>
+                    <dd>{invoice.paidTransactionId ?? '—'}</dd>
+                  </div>
+                </dl>
+
+                <div className="invoice-actions">
+                  <button type="button" onClick={() => handleCopyMemo(invoice.memo)}>
+                    Copy memo
+                  </button>
+                  {invoice.status === 'paid' && (
+                    <button type="button" onClick={() => handleExportReceipt(invoice)}>
+                      Export receipt PDF
+                    </button>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/merchant-pos/src/lib/invoices.test.ts
+++ b/apps/merchant-pos/src/lib/invoices.test.ts
@@ -1,0 +1,70 @@
+import type { Transaction } from '@qzd/sdk-browser';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createInvoice,
+  encodeInvoicePayload,
+  transactionMatchesInvoice,
+  type InvoiceInput,
+} from './invoices';
+
+vi.stubGlobal('crypto', {
+  randomUUID: () => '123e4567-e89b-12d3-a456-426614174000',
+});
+
+function buildTransaction(partial: Partial<Transaction>): Transaction {
+  return {
+    id: 'txn_1',
+    accountId: 'acc_merchant',
+    type: 'transfer',
+    status: 'posted',
+    amount: { value: '25.00', currency: 'QZD' },
+    createdAt: new Date().toISOString(),
+    ...partial,
+  } as Transaction;
+}
+
+describe('invoices helpers', () => {
+  const baseInput: InvoiceInput = {
+    accountId: 'acc_merchant',
+    amountValue: '25',
+    currency: 'qzd',
+  };
+
+  it('creates invoices with normalized values', () => {
+    const invoice = createInvoice(baseInput);
+    expect(invoice.accountId).toBe(baseInput.accountId);
+    expect(invoice.amount.value).toBe('25.00');
+    expect(invoice.amount.currency).toBe('QZD');
+    expect(invoice.reference).toMatch(/^INV-/);
+    expect(invoice.status).toBe('pending');
+  });
+
+  it('encodes QR payloads as JSON strings', () => {
+    const invoice = createInvoice(baseInput);
+    const payload = encodeInvoicePayload(invoice);
+    expect(() => JSON.parse(payload)).not.toThrow();
+    const parsed = JSON.parse(payload);
+    expect(parsed).toMatchObject({
+      type: 'qzd.invoice.v1',
+      invoiceId: invoice.id,
+      reference: invoice.reference,
+      amount: invoice.amount,
+    });
+  });
+
+  it('matches transactions when memo includes the invoice reference', () => {
+    const invoice = createInvoice(baseInput);
+    const transaction = buildTransaction({
+      metadata: { memo: `Invoice ${invoice.reference}` },
+    });
+
+    expect(transactionMatchesInvoice(transaction, invoice)).toBe(true);
+  });
+
+  it('does not match when memo is missing the reference', () => {
+    const invoice = createInvoice(baseInput);
+    const transaction = buildTransaction({ metadata: { memo: 'Different memo' } });
+
+    expect(transactionMatchesInvoice(transaction, invoice)).toBe(false);
+  });
+});

--- a/apps/merchant-pos/src/lib/invoices.ts
+++ b/apps/merchant-pos/src/lib/invoices.ts
@@ -1,0 +1,128 @@
+import type { Transaction } from '@qzd/sdk-browser';
+
+export type InvoiceStatus = 'pending' | 'paid';
+
+export interface InvoiceInput {
+  accountId: string;
+  amountValue: string;
+  currency: string;
+  description?: string;
+  customerName?: string;
+}
+
+export interface Invoice {
+  id: string;
+  accountId: string;
+  amount: {
+    value: string;
+    currency: string;
+  };
+  description?: string;
+  customerName?: string;
+  reference: string;
+  memo: string;
+  createdAt: string;
+  status: InvoiceStatus;
+  paidTransactionId?: string;
+  paidAt?: string | Date;
+  qrCodeDataUrl?: string;
+}
+
+export interface PaymentMatch {
+  invoiceId: string;
+  transactionId: string;
+  paidAt: string | Date;
+}
+
+function sanitizeDecimal(input: string): string {
+  return Number.parseFloat(input).toFixed(2);
+}
+
+export function generateInvoiceId(): string {
+  const randomSuffix = Math.random().toString(16).slice(2, 10);
+  return `inv_${Date.now()}_${randomSuffix}`;
+}
+
+export function createInvoice(input: InvoiceInput): Invoice {
+  const accountId = input.accountId.trim();
+  if (!accountId) {
+    throw new Error('Account ID is required');
+  }
+
+  const amountValue = input.amountValue.trim();
+  if (!amountValue) {
+    throw new Error('Invoice amount is required');
+  }
+
+  const currency = (input.currency || 'QZD').trim().toUpperCase();
+  const amountNumber = Number.parseFloat(amountValue);
+  if (!Number.isFinite(amountNumber) || amountNumber <= 0) {
+    throw new Error('Invoice amount must be a positive decimal');
+  }
+
+  const id = generateInvoiceId();
+  const reference = `INV-${id.slice(4, 10).toUpperCase()}`;
+
+  return {
+    id,
+    accountId,
+    amount: {
+      value: sanitizeDecimal(amountValue),
+      currency,
+    },
+    description: input.description?.trim() || undefined,
+    customerName: input.customerName?.trim() || undefined,
+    reference,
+    memo: `Invoice ${reference}`,
+    createdAt: new Date().toISOString(),
+    status: 'pending',
+  } satisfies Invoice;
+}
+
+export function encodeInvoicePayload(invoice: Invoice): string {
+  const payload = {
+    type: 'qzd.invoice.v1',
+    invoiceId: invoice.id,
+    accountId: invoice.accountId,
+    amount: invoice.amount,
+    reference: invoice.reference,
+    memo: invoice.memo,
+    description: invoice.description,
+    customerName: invoice.customerName,
+  };
+
+  return JSON.stringify(payload);
+}
+
+export function transactionMatchesInvoice(transaction: Transaction, invoice: Invoice): boolean {
+  if (!transaction || !invoice) {
+    return false;
+  }
+
+  if (transaction.accountId !== invoice.accountId) {
+    return false;
+  }
+
+  if (transaction.status !== 'posted') {
+    return false;
+  }
+
+  const amountMatches =
+    transaction.amount?.currency === invoice.amount.currency &&
+    transaction.amount?.value === invoice.amount.value;
+
+  if (!amountMatches) {
+    return false;
+  }
+
+  const memo = transaction.metadata?.memo ?? '';
+  return memo.includes(invoice.reference);
+}
+
+export function buildPaymentMatch(transaction: Transaction, invoice: Invoice): PaymentMatch {
+  return {
+    invoiceId: invoice.id,
+    transactionId: transaction.id,
+    paidAt: transaction.createdAt,
+  };
+}

--- a/apps/merchant-pos/src/main.tsx
+++ b/apps/merchant-pos/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/apps/merchant-pos/src/setupTests.ts
+++ b/apps/merchant-pos/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/apps/merchant-pos/src/styles.css
+++ b/apps/merchant-pos/src/styles.css
@@ -1,0 +1,200 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.4;
+  color: #101828;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  background-color: #f8fafc;
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+main > header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+main > header h1 {
+  margin: 0;
+  font-size: 2.25rem;
+}
+
+section {
+  background-color: #ffffff;
+  border-radius: 12px;
+  padding: 1.75rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+section h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+form {
+  display: grid;
+  gap: 1rem;
+}
+
+.auth-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .auth-layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.auth-form {
+  border: 1px solid #e0e7ff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  background-color: #f9fbff;
+  display: grid;
+  gap: 1rem;
+}
+
+.auth-form h3 {
+  margin: 0;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+input,
+textarea,
+select {
+  padding: 0.75rem 0.85rem;
+  font-size: 1rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  background-color: #f8f9ff;
+}
+
+input:disabled,
+textarea:disabled,
+select:disabled,
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button {
+  padding: 0.85rem 1.5rem;
+  font-size: 1rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(99, 102, 241, 0.25);
+}
+
+.status-message {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background-color: #eef2ff;
+  color: #4338ca;
+}
+
+.invoice-list {
+  display: grid;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.invoice-card {
+  border: 1px solid #e0e7ff;
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+  background-color: #f9fbff;
+}
+
+.invoice-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.invoice-status {
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.invoice-status[data-status='pending'] {
+  color: #b45309;
+}
+
+.invoice-status[data-status='paid'] {
+  color: #16a34a;
+}
+
+.invoice-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.qr-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.qr-wrapper img {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  max-width: 220px;
+}
+
+.qr-wrapper textarea {
+  resize: none;
+  font-family: 'Source Code Pro', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
+}
+
+.details-grid {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.details-grid dt {
+  font-weight: 600;
+}
+
+.details-grid dd {
+  margin: 0;
+}
+
+textarea {
+  min-height: 96px;
+}

--- a/apps/merchant-pos/tsconfig.json
+++ b/apps/merchant-pos/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.cache/tsbuildinfo.json",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["vitest/globals", "vite/client", "@testing-library/jest-dom"]
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/apps/merchant-pos/tsconfig.node.json
+++ b/apps/merchant-pos/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "vitest.config.ts"]
+}

--- a/apps/merchant-pos/vite.config.ts
+++ b/apps/merchant-pos/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/apps/merchant-pos/vitest.config.ts
+++ b/apps/merchant-pos/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/setupTests.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,55 @@ importers:
         specifier: ^1.3.1
         version: 1.6.1(@types/node@20.19.17)
 
+  apps/merchant-pos:
+    dependencies:
+      '@qzd/sdk-browser':
+        specifier: workspace:*
+        version: link:../../packages/sdk-browser
+      jspdf:
+        specifier: ^2.5.2
+        version: 2.5.2
+      qrcode:
+        specifier: ^1.5.3
+        version: 1.5.4
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.3.0
+        version: 6.8.0
+      '@testing-library/react':
+        specifier: ^14.1.2
+        version: 14.3.1(@types/react@18.3.24)(react-dom@18.3.1)(react@18.3.1)
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.5
+      '@types/react':
+        specifier: ^18.2.46
+        version: 18.3.24
+      '@types/react-dom':
+        specifier: ^18.2.18
+        version: 18.3.7(@types/react@18.3.24)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.20)
+      jsdom:
+        specifier: ^24.0.0
+        version: 24.1.3
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.2
+      vite:
+        specifier: ^5.1.4
+        version: 5.4.20(@types/node@20.19.17)
+      vitest:
+        specifier: ^1.3.1
+        version: 1.6.1(jsdom@24.1.3)
+
   apps/sms-sim: {}
 
   apps/wallet-web:
@@ -515,7 +564,6 @@ packages:
   /@babel/runtime@7.28.4:
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/template@7.27.2:
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
@@ -3800,9 +3848,21 @@ packages:
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
     dev: true
 
+  /@types/qrcode@1.5.5:
+    resolution: {integrity: sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==}
+    dependencies:
+      '@types/node': 20.19.17
+    dev: true
+
   /@types/qs@6.14.0:
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
     dev: true
+
+  /@types/raf@3.4.3:
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@types/range-parser@1.2.7:
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
@@ -4295,6 +4355,12 @@ packages:
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  /atob@2.1.2:
+    resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
+    engines: {node: '>= 4.5.0'}
+    hasBin: true
+    dev: false
+
   /atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -4319,6 +4385,13 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
+
+  /base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -4424,6 +4497,12 @@ packages:
       update-browserslist-db: 1.1.3(browserslist@4.26.2)
     dev: true
 
+  /btoa@1.2.1:
+    resolution: {integrity: sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==}
+    engines: {node: '>= 0.4.0'}
+    hasBin: true
+    dev: false
+
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -4492,6 +4571,11 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+    dev: false
+
   /camelize@1.0.1:
     resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
     dev: true
@@ -4499,6 +4583,22 @@ packages:
   /caniuse-lite@1.0.30001743:
     resolution: {integrity: sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==}
     dev: true
+
+  /canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
+    requiresBuild: true
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@types/raf': 3.4.3
+      core-js: 3.45.1
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    dev: false
+    optional: true
 
   /caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
@@ -4603,6 +4703,14 @@ packages:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
     dev: true
+
+  /cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+    dev: false
 
   /cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -4777,7 +4885,6 @@ packages:
   /core-js@3.45.1:
     resolution: {integrity: sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==}
     requiresBuild: true
-    dev: true
 
   /cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -4811,6 +4918,14 @@ packages:
     resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
     engines: {node: '>=4'}
     dev: true
+
+  /css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
+    requiresBuild: true
+    dependencies:
+      utrie: 1.0.2
+    dev: false
+    optional: true
 
   /css-to-react-native@3.2.0:
     resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
@@ -4870,6 +4985,11 @@ packages:
     dependencies:
       ms: 2.1.3
       supports-color: 10.2.2
+
+  /decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -4977,6 +5097,10 @@ packages:
     engines: {node: '>=0.3.1'}
     dev: true
 
+  /dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+    dev: false
+
   /dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
     dev: true
@@ -4984,6 +5108,12 @@ packages:
   /dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
     dev: true
+
+  /dompurify@2.5.8:
+    resolution: {integrity: sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /dompurify@3.2.7:
     resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
@@ -5563,6 +5693,14 @@ packages:
       locate-path: 2.0.0
     dev: true
 
+  /find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+    dev: false
+
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -5894,6 +6032,16 @@ packages:
     dependencies:
       whatwg-encoding: 3.1.1
     dev: true
+
+  /html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+    requiresBuild: true
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    dev: false
+    optional: true
 
   /http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
@@ -6528,6 +6676,20 @@ packages:
     hasBin: true
     dev: true
 
+  /jspdf@2.5.2:
+    resolution: {integrity: sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==}
+    dependencies:
+      '@babel/runtime': 7.28.4
+      atob: 2.1.2
+      btoa: 1.2.1
+      fflate: 0.8.2
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.45.1
+      dompurify: 2.5.8
+      html2canvas: 1.4.1
+    dev: false
+
   /keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
@@ -6601,6 +6763,13 @@ packages:
       p-locate: 2.0.0
       path-exists: 3.0.0
     dev: true
+
+  /locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-locate: 4.1.0
+    dev: false
 
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -7162,6 +7331,13 @@ packages:
       p-try: 1.0.0
     dev: true
 
+  /p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+    dependencies:
+      p-try: 2.2.0
+    dev: false
+
   /p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -7183,6 +7359,13 @@ packages:
       p-limit: 1.3.0
     dev: true
 
+  /p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+    dependencies:
+      p-limit: 2.3.0
+    dev: false
+
   /p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
@@ -7194,6 +7377,11 @@ packages:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
     engines: {node: '>=4'}
     dev: true
+
+  /p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+    dev: false
 
   /pac-proxy-agent@7.2.0:
     resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
@@ -7279,7 +7467,6 @@ packages:
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -7343,6 +7530,12 @@ packages:
   /perfect-scrollbar@1.5.6:
     resolution: {integrity: sha512-rixgxw3SxyJbCaSpo1n35A/fwI1r2rdwMKOTCg/AcG+xOEyZcE8UHVjpZMFCVImzsFoCZeJTT+M/rdEIQYO2nw==}
     dev: true
+
+  /performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -7425,6 +7618,11 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
     dev: true
+
+  /pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
+    dev: false
 
   /polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
@@ -7652,6 +7850,16 @@ packages:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
     dev: true
 
+  /qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
+    dev: false
+
   /qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
@@ -7676,6 +7884,14 @@ packages:
   /quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
     dev: true
+
+  /raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+    requiresBuild: true
+    dependencies:
+      performance-now: 2.1.0
+    dev: false
+    optional: true
 
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -7815,6 +8031,12 @@ packages:
     resolution: {integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==}
     dev: true
 
+  /regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -7845,6 +8067,10 @@ packages:
       resolve: 1.22.10
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
     dev: false
 
   /requires-port@1.0.0:
@@ -7883,6 +8109,13 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
     dev: true
+
+  /rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /rimraf@6.0.1:
     resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
@@ -8030,6 +8263,10 @@ packages:
       send: 0.19.0
     transitivePeerDependencies:
       - supports-color
+
+  /set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+    dev: false
 
   /set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
@@ -8268,6 +8505,13 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
+  /stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /start-server-and-test@2.1.2:
     resolution: {integrity: sha512-OIjfo3G6QV9Sh6IlMqj58oZwVhPVuU/l6uVACG7YNE9kAfDvcYoPThtb0NNT3tZMMC3wOYbXnC15yiCSNFkdRg==}
     engines: {node: '>=16'}
@@ -8490,6 +8734,13 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
+  /svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /swagger2openapi@7.0.8:
     resolution: {integrity: sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==}
     hasBin: true
@@ -8518,6 +8769,14 @@ packages:
     dependencies:
       bintrees: 1.0.2
     dev: false
+
+  /text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+    requiresBuild: true
+    dependencies:
+      utrie: 1.0.2
+    dev: false
+    optional: true
 
   /thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -8870,6 +9129,14 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  /utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
+    requiresBuild: true
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    dev: false
+    optional: true
+
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -9191,6 +9458,10 @@ packages:
       is-weakset: 2.0.4
     dev: true
 
+  /which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+    dev: false
+
   /which-typed-array@1.1.19:
     resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
     engines: {node: '>= 0.4'}
@@ -9237,7 +9508,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -9299,6 +9569,10 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  /y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+    dev: false
+
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -9316,6 +9590,14 @@ packages:
     engines: {node: '>= 6'}
     dev: true
 
+  /yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+    dev: false
+
   /yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -9324,6 +9606,23 @@ packages:
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  /yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
+    dev: false
 
   /yargs@16.2.0:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}


### PR DESCRIPTION
## Summary
- add a new Vite-based merchant POS workspace for creating QR invoices, polling for wallet payments, and exporting PDF receipts
- implement reusable invoice helpers and tests to match transfers to invoice references
- style the point-of-sale dashboard with responsive layouts and QR memo presentation

## Testing
- pnpm --filter @qzd/merchant-pos lint
- pnpm --filter @qzd/merchant-pos typecheck
- pnpm --filter @qzd/merchant-pos test

------
https://chatgpt.com/codex/tasks/task_e_68dacd2a24948330956971dcddd023f3