### PR TITLE
Add deterministic quote simulation with scenario docs

### DIFF
--- a/apps/api/src/remittances.service.spec.ts
+++ b/apps/api/src/remittances.service.spec.ts
@@ -21,16 +21,19 @@ describe('RemittancesService', () => {
     const service = new RemittancesService(clock);
 
     const baseline = service.simulateQuote('100.00', 'DEFAULT');
+    expect(baseline.quoteId).toBe('quote_default_000001');
     expect(baseline.buyAmount.value).toBe('772.28');
     expect(baseline.rate).toBe('7.7228');
 
-    const subsidized = service.simulateQuote('100.00', 'SUBSIDIZED');
-    expect(subsidized.buyAmount.value).toBe('780.00');
-    expect(subsidized.rate).toBe('7.8000');
-
     const tariffed = service.simulateQuote('100.00', 'TARIFFED');
+    expect(tariffed.quoteId).toBe('quote_tariffed_000002');
     expect(tariffed.buyAmount.value).toBe('756.60');
     expect(tariffed.rate).toBe('7.5660');
+
+    const subsidized = service.simulateQuote('100.00', 'SUBSIDIZED');
+    expect(subsidized.quoteId).toBe('quote_subsidized_000003');
+    expect(subsidized.buyAmount.value).toBe('780.00');
+    expect(subsidized.rate).toBe('7.8000');
   });
 
   it('mints QZD with multisig signatures', () => {

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -752,8 +752,17 @@ paths:
             Pricing program to apply to the remittance quote. Allowed values: DEFAULT,
             TARIFFED, SUBSIDIZED.
           schema:
-            type: string
-          example: DEFAULT
+            $ref: '#/components/schemas/QuoteScenario'
+          examples:
+            default:
+              summary: Standard program
+              value: DEFAULT
+            tariffed:
+              summary: Tariffed program (3% fee)
+              value: TARIFFED
+            subsidized:
+              summary: Subsidized program (no fee)
+              value: SUBSIDIZED
       responses:
         '200':
           description: Quote simulated successfully.
@@ -761,16 +770,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/QuoteResponse'
-              example:
-                quoteId: "quote_default_100"
-                sellAmount:
-                  currency: "USD"
-                  value: "100.00"
-                buyAmount:
-                  currency: "QZD"
-                  value: "772.28"
-                rate: "7.7228"
-                expiresAt: "2024-05-02T12:00:00Z"
+              examples:
+                default:
+                  summary: DEFAULT scenario with flat $0.99 fee
+                  value:
+                    quoteId: "quote_default_000001"
+                    sellAmount:
+                      currency: "USD"
+                      value: "100.00"
+                    buyAmount:
+                      currency: "QZD"
+                      value: "772.28"
+                    rate: "7.7228"
+                    expiresAt: "2024-05-02T12:00:00Z"
+                tariffed:
+                  summary: TARIFFED scenario with 3% fee
+                  value:
+                    quoteId: "quote_tariffed_000002"
+                    sellAmount:
+                      currency: "USD"
+                      value: "100.00"
+                    buyAmount:
+                      currency: "QZD"
+                      value: "756.60"
+                    rate: "7.5660"
+                    expiresAt: "2024-05-02T12:00:00Z"
+                subsidized:
+                  summary: SUBSIDIZED scenario with no fee
+                  value:
+                    quoteId: "quote_subsidized_000003"
+                    sellAmount:
+                      currency: "USD"
+                      value: "100.00"
+                    buyAmount:
+                      currency: "QZD"
+                      value: "780.00"
+                    rate: "7.8000"
+                    expiresAt: "2024-05-02T12:00:00Z"
         '400':
           $ref: '#/components/responses/BadRequestError'
         '401':
@@ -1546,12 +1582,9 @@ components:
           type: string
           description: Beneficiary phone number when an account identifier is unavailable.
         scenario:
-          type: string
           description: Optional pricing program override for this acquisition.
-          enum:
-            - DEFAULT
-            - TARIFFED
-            - SUBSIDIZED
+          allOf:
+            - $ref: '#/components/schemas/QuoteScenario'
       required:
         - usdAmount
         - senderPhone
@@ -1665,3 +1698,10 @@ components:
       required:
         - code
         - message
+    QuoteScenario:
+      type: string
+      description: Pricing program applied to a remittance quote.
+      enum:
+        - DEFAULT
+        - TARIFFED
+        - SUBSIDIZED

--- a/packages/shared/src/oas-types.ts
+++ b/packages/shared/src/oas-types.ts
@@ -532,11 +532,8 @@ export type components = {
             receiverAccountId?: string;
             /** @description Beneficiary phone number when an account identifier is unavailable. */
             receiverPhone?: string;
-            /**
-             * @description Optional pricing program override for this acquisition.
-             * @enum {string}
-             */
-            scenario?: "DEFAULT" | "TARIFFED" | "SUBSIDIZED";
+            /** @description Optional pricing program override for this acquisition. */
+            scenario?: components["schemas"]["QuoteScenario"];
         };
         QuoteResponse: {
             quoteId: string;
@@ -584,6 +581,11 @@ export type components = {
                 [key: string]: string;
             };
         };
+        /**
+         * @description Pricing program applied to a remittance quote.
+         * @enum {string}
+         */
+        QuoteScenario: "DEFAULT" | "TARIFFED" | "SUBSIDIZED";
     };
     responses: {
         /** @description Invalid request payload or parameters. */
@@ -1398,13 +1400,10 @@ export interface operations {
             query: {
                 /** @example 100.00 */
                 usdAmount: string;
-                /**
-                 * @description Pricing program to apply to the remittance quote. Allowed values: DEFAULT,
+                /** @description Pricing program to apply to the remittance quote. Allowed values: DEFAULT,
                  *     TARIFFED, SUBSIDIZED.
-                 *
-                 * @example DEFAULT
-                 */
-                scenario?: string;
+                 *      */
+                scenario?: components["schemas"]["QuoteScenario"];
             };
             header?: never;
             path?: never;
@@ -1418,19 +1417,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    /** @example {
-                     *       "quoteId": "quote_default_100",
-                     *       "sellAmount": {
-                     *         "currency": "USD",
-                     *         "value": "100.00"
-                     *       },
-                     *       "buyAmount": {
-                     *         "currency": "QZD",
-                     *         "value": "772.28"
-                     *       },
-                     *       "rate": "7.7228",
-                     *       "expiresAt": "2024-05-02T12:00:00Z"
-                     *     } */
                     "application/json": components["schemas"]["QuoteResponse"];
                 };
             };


### PR DESCRIPTION
## Summary
- replace the remittance quote math with deterministic minor-unit calculations and sequential quote ids
- document DEFAULT, TARIFFED, and SUBSIDIZED quote scenarios in the OpenAPI spec and shared types
- surface a wallet scenario toggle with contextual display of the selected program

## Testing
- pnpm --filter @qzd/api test -- src/remittances.service.spec.ts
- pnpm --filter @qzd/wallet-web test
- pnpm --filter @qzd/api typecheck
- pnpm --filter @qzd/wallet-web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dad6057c2c833095e023efdb5db69a