### PR TITLE
docs: publish developer guides and redoc

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -135,6 +135,7 @@ services:
     image: nginx:1.25-alpine
     volumes:
       - ./docs:/usr/share/nginx/html:ro
+      - ./openapi/openapi.yaml:/usr/share/nginx/html/openapi.yaml:ro
     ports:
       - "8080:80"
     restart: unless-stopped

--- a/docs/api-readme.md
+++ b/docs/api-readme.md
@@ -1,0 +1,60 @@
+# API Workflow Guide
+
+The Quetzal Digital API is defined in [`openapi/openapi.yaml`](../openapi/openapi.yaml).
+All server handlers, SDKs, contract tests, and external documentation are generated
+from this source of truth. Follow the workflow below whenever you need to change
+an endpoint or schema.
+
+## 1. Propose and edit the OpenAPI contract
+
+1. Create a feature branch and update `openapi/openapi.yaml` with the
+   desired changes. Keep tag descriptions and operation summaries consistent
+   with the domain language used in the client applications.
+2. Validate the contract locally before touching any code:
+
+   ```bash
+   pnpm oas:lint
+   ```
+
+   The command runs Redocly linting and will fail if breaking changes or
+   documentation gaps are detected.
+
+## 2. Regenerate server stubs and SDKs
+
+Regenerate all derived artifacts so that the NestJS controllers and the TypeScript
+clients stay aligned with the spec:
+
+```bash
+pnpm gen:sdks    # server + browser + node SDKs
+pnpm gen:types   # shared TypeScript types consumed by @qzd/shared
+```
+
+You can also run `pnpm gen:all` to execute both commands in sequence. Never edit
+files under `packages/sdk-api/src/*/generated`—they are replaced on every run.
+
+## 3. Update tests and documentation
+
+- Adjust handlers in `apps/api` and supporting domain packages to satisfy the new
+  contract. Keep handlers thin and defer validation to the generated DTOs.
+- Update Vitest suites, contract tests (`pnpm test:contract`), and manuals so they
+  describe the new behaviour.
+- Rebuild the HTML preview of the specification if you want to share it outside
+  the monorepo:
+
+  ```bash
+  pnpm oas:docs   # outputs to openapi/dist/index.html
+  ```
+
+## 4. Verify before committing
+
+Run the monorepo quality gates before raising a pull request:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm test:contract
+```
+
+The Husky hooks enforce these checks on CI, so running them locally keeps the
+pipeline green. Capture any notable manual validation in your PR description.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,43 @@
+# System Architecture
+
+Quetzal Digital is organised as a pnpm-managed monorepo with a clear separation
+between runtime applications, reusable packages, and generated SDKs.
+
+## High-level topology
+
+- **API (`apps/api`)** – NestJS service that exposes the OpenAPI contract defined
+  in `openapi/openapi.yaml`. It orchestrates the in-memory ledger, validates
+  requests with generated DTOs, and emits Prometheus metrics.
+- **Wallet Web (`apps/wallet-web`)** – Vite + React single-page app for retail
+  customers. It consumes the browser SDK to register, load balances, send
+  transfers, and preview remittance quotes.
+- **Admin Web (`apps/admin-web`)** – React console for operations teams to review
+  alerts, shepherd issuance requests to completion, and redeem agent vouchers.
+- **Merchant POS (`apps/merchant-pos`)** – React-based point-of-sale terminal that
+  issues QR-code invoices and reconciles incoming wallet transfers.
+- **SMS Simulator (`apps/sms-sim`)** – Node.js CLI that reproduces inbound SMS
+  traffic against the `/sms/inbound` endpoint for manual testing.
+
+Support packages include:
+
+- **`packages/shared`** – TypeScript types shared across apps. Hosts the generated
+  OpenAPI typings consumed by UI forms.
+- **`packages/ledger`** – Append-only ledger and signature primitives used by the
+  API service.
+- **`packages/sdk`** – Thin wrappers around the generated API clients, adding
+  ergonomic helpers and auth integration.
+- **`packages/sdk-api`** – Generated clients for NestJS, browser fetch, and Axios
+  environments. Never edit files in the `generated` directories.
+
+## Environment orchestration
+
+`docker-compose.yaml` spins up the entire developer stack:
+
+- Postgres for persistence, seeded via `pnpm --filter @qzd/api exec node scripts/seed-dev.mjs`.
+- The API service plus Wallet, Admin, Merchant POS, and SMS simulator frontends.
+- Prism mock server for contract testing at <http://localhost:4010>.
+- Observability stack (Prometheus + Grafana).
+- Static docs served from `docs/` alongside a Redoc rendering of the contract.
+
+Use `make dev` to launch the full stack or `make mock` when only Prism-backed
+contract testing is required.

--- a/docs/contrib.md
+++ b/docs/contrib.md
@@ -1,0 +1,31 @@
+# Contributor Checklist
+
+Follow this checklist before requesting a review. It mirrors the repository
+automation (Husky + GitHub Actions) and the expectations documented in
+`AGENTS.md`.
+
+## Pre-flight
+
+- [ ] The change is described in the pull request summary with context and links
+      to any related issues.
+- [ ] Conventional Commit message prepared (e.g. `feat(api): add cash-out limit`).
+- [ ] New environment variables, migrations, or docker-compose updates are
+      called out in the PR description.
+
+## Quality gates
+
+- [ ] `pnpm lint`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm test`
+- [ ] `pnpm test:contract` (required whenever the OpenAPI contract or SDKs
+      change)
+- [ ] `pnpm gen:sdks` (run and commit results when the contract changes)
+
+## Documentation
+
+- [ ] OpenAPI spec updates live in `openapi/openapi.yaml` and were linted with
+      `pnpm oas:lint`.
+- [ ] Redoc preview rebuilt with `pnpm oas:docs` when sharing external contract
+      updates.
+- [ ] Relevant manuals in `docs/manuals/` mention new user-facing behaviour.
+- [ ] `docs/index.html` links to any new documentation artefacts.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -6,7 +6,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
       body {
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
         margin: 0;
         padding: 3rem 1.5rem;
         background: #0f172a;
@@ -28,6 +33,11 @@
         margin-top: 0;
         font-size: 2.5rem;
         letter-spacing: 0.04em;
+      }
+      h2 {
+        margin-top: 2rem;
+        font-size: 1.5rem;
+        letter-spacing: 0.02em;
       }
       p {
         line-height: 1.6;
@@ -54,23 +64,40 @@
     <main>
       <h1>Quetzal Digital Developer Hub</h1>
       <p>
-        Welcome to the Quetzal Digital developer experience stack. This lightweight
-        documentation portal is served via the <code>docs</code> service inside the
-        development Docker Compose file.
+        This portal is served from the <code>docs</code> service defined in
+        <code>docker-compose.yaml</code>. Use it as the starting point for onboarding, contract
+        updates, and operational playbooks.
       </p>
-      <p>
-        Explore the available surfaces while the stack is running:
-      </p>
+
+      <h2>Core references</h2>
+      <ul>
+        <li><a href="api-readme.md">API workflow guide</a></li>
+        <li><a href="architecture.md">System architecture overview</a></li>
+        <li><a href="runbook.md">Operations runbook</a></li>
+        <li><a href="contrib.md">Contributor checklist</a></li>
+        <li><a href="redoc.html">OpenAPI (Redoc)</a></li>
+      </ul>
+
+      <h2>Actor manuals</h2>
+      <ul>
+        <li><a href="manuals/wallet-user.md">Wallet user</a></li>
+        <li><a href="manuals/admin-operator.md">Admin operator</a></li>
+        <li><a href="manuals/merchant-operator.md">Merchant POS operator</a></li>
+        <li><a href="manuals/sms-operator.md">SMS operations</a></li>
+      </ul>
+
+      <h2>Runtime surfaces</h2>
       <ul>
         <li><a href="http://localhost:3000">API (NestJS)</a></li>
-        <li><a href="http://localhost:5173">Wallet Web (Vite)</a></li>
-        <li><a href="http://localhost:5174">Admin Web (Vite)</a></li>
-        <li><a href="http://localhost:4010">Prism Mock Server</a></li>
-        <li><a href="http://localhost:8080">Docs (this site)</a></li>
+        <li><a href="http://localhost:5173">Wallet web</a></li>
+        <li><a href="http://localhost:5174">Admin web</a></li>
+        <li>Merchant POS (start locally on port 5175)</li>
+        <li><a href="http://localhost:4010">Prism mock server</a></li>
       </ul>
+
       <p>
-        Use <code>make dev</code> to launch the full developer stack or
-        <code>make mock</code> when you only need the mock services.
+        Use <code>make dev</code> to launch the full stack or <code>make mock</code> to start only
+        the API + mock infrastructure.
       </p>
     </main>
   </body>

--- a/docs/manuals/admin-operator.md
+++ b/docs/manuals/admin-operator.md
@@ -1,0 +1,51 @@
+# Admin Operator Manual
+
+The admin console (`apps/admin-web`) gives operations staff tools to manage
+issuance queues and agent vouchers. It expects a privileged access token issued
+by the API.
+
+## Prerequisites
+
+- Admin service running via `pnpm --filter @qzd/admin-web dev -- --host 0.0.0.0`
+  or `docker compose up admin-web`.
+- API reachable from the browser (default `http://localhost:3000`).
+- Access token generated through an admin authentication flow.
+
+## Connect to the API
+
+1. Enter the API base URL if different from the default.
+2. Paste a bearer token with admin privileges.
+3. Submit **Save connection**. Subsequent requests include the token in the
+   `Authorization` header.
+
+## Redeem agent vouchers
+
+1. Open **Voucher redemption**.
+2. Paste the voucher code provided by a field agent.
+3. Submit to call `POST /agents/vouchers/{code}/redeem`. The UI displays amount,
+   fees, timestamps, and metadata returned by the API.
+4. Share the confirmation message with the agent if needed.
+
+## Create an issuance request
+
+1. In **Create issuance request**, provide the customer account ID, amount, and
+   optional reference memo.
+2. Submit to invoke `POST /admin/issuance-requests`. The console clears the form
+   and refreshes the queue.
+3. Use consistent currency codes (`QZD`, `USD`, etc.) to align with ledger rules.
+
+## Sign issuance requests
+
+1. Choose the validator identity from the dropdown (defaults to `validator-1`).
+2. Click **Refresh queue** to load pending items via
+   `GET /admin/issuance-requests`.
+3. For each request, press **Sign as ...** to call
+   `POST /admin/issuance-requests/{id}/sign`. The UI manages idempotency keys.
+4. Completed requests disappear once the quorum is met.
+
+## Tips
+
+- Keep the console open while processing requests so the automatic refresh can
+  fetch new items after each action.
+- Validation errors return detailed messages; surface them in support channels so
+  API teams can adjust the OpenAPI contract if needed.

--- a/docs/manuals/merchant-operator.md
+++ b/docs/manuals/merchant-operator.md
@@ -1,0 +1,47 @@
+# Merchant POS Manual
+
+The merchant POS (`apps/merchant-pos`) allows cashiers to issue QR-code invoices
+and confirm payments against the transaction history of a merchant account.
+
+## Prerequisites
+
+- POS app running via `pnpm --filter @qzd/merchant-pos dev -- --host 0.0.0.0` or
+  `docker compose up merchant-pos`.
+- API reachable from the browser (`http://localhost:3000` by default).
+- Merchant account provisioned in the API.
+
+## Authenticate
+
+1. Register a merchant operator under **Create operator account** to call
+   `POST /auth/register` if needed.
+2. Sign in with the credentials to invoke `POST /auth/login` and obtain a session
+   token. The UI keeps the token in memory.
+
+## Select an account to monitor
+
+1. Enter the merchant account ID in **Monitor account**.
+2. Submit to focus the dashboard on that account. Any existing invoices for other
+   accounts are hidden to avoid mix-ups.
+
+## Create an invoice
+
+1. Fill in amount, currency, optional customer name, and description.
+2. Submit to generate an invoice payload and QR code. The memo string encodes the
+   invoice; share it with the payer.
+3. The invoice is stored locally with status `pending` until a matching payment
+   is detected.
+
+## Confirm payments
+
+- The POS polls `GET /accounts/{id}/transactions` every five seconds. When a
+  transaction memo matches a pending invoice, the UI marks it as **Paid**, records
+  the transaction ID, and timestamps the payment.
+- Operators can export a PDF receipt or copy the memo from the invoice card.
+
+## Troubleshooting
+
+- **No payments detected** – Verify the wallet transfer memo exactly matches the
+  invoice memo and that the transfer targeted the correct account.
+- **Token expired** – Re-authenticate to refresh the session token.
+- **QR code missing** – Regenerate the invoice; the QR code is derived from the
+  memo payload and requires the QRCode library to load.

--- a/docs/manuals/sms-operator.md
+++ b/docs/manuals/sms-operator.md
@@ -1,0 +1,39 @@
+# SMS Operations Manual
+
+The SMS simulator (`apps/sms-sim`) is a Node.js CLI used to reproduce inbound
+messages against the `/sms/inbound` API endpoint. Use it for QA and to verify the
+runbook steps for SMS regressions.
+
+## Prerequisites
+
+- Node.js 20 (provided by Docker Compose or your local environment).
+- API running and reachable at the base URL you intend to target.
+
+## Launch the simulator
+
+```bash
+pnpm --filter @qzd/sms-sim start -- --base http://localhost:3000 --from 5025551000
+```
+
+Options:
+
+- `--base` (or `-b`) sets the API base URL. Defaults to `http://localhost:3000`.
+- `--from` (or `-f`) configures the MSISDN that will appear in the request body.
+
+## Interactive commands
+
+Once the prompt is active:
+
+- Type an SMS payload (e.g. `BAL` or `SEND 50 5025552222`) and press Enter. The
+  CLI issues `POST /sms/inbound` and prints the API reply prefixed with `<<`.
+- Use `/from <msisdn>` to change the sender without restarting the process.
+- Use `/base <url>` to update the target API URL.
+- Use `/quit` or `/exit` to stop the simulator.
+
+## Error handling
+
+- Non-2xx responses surface as `API error <status>: <message>` messages.
+- Malformed responses (missing `reply`) raise validation errors so handlers can
+  be fixed before shipping to production.
+
+Document repeatable SMS scenarios in this manual so QA can replay them quickly.

--- a/docs/manuals/wallet-user.md
+++ b/docs/manuals/wallet-user.md
@@ -1,0 +1,48 @@
+# Wallet User Manual
+
+The wallet web application (`apps/wallet-web`) helps retail customers manage
+QZD accounts. It uses the browser SDK to call the API exposed at
+`http://localhost:3000` by default.
+
+## Prerequisites
+
+- Wallet service running via `pnpm --filter @qzd/wallet-web dev -- --host 0.0.0.0` or
+  `docker compose up wallet-web`.
+- API reachable at the base URL configured in `VITE_API_BASE_URL`.
+- An account ID issued by the API or the dev seed script.
+
+## Sign up or sign in
+
+1. Enter the API base URL if you are not targeting the default `http://localhost:3000`.
+2. Use **Create account** to register with an email, password, and full name.
+   This calls `POST /auth/register` followed by `POST /accounts`.
+3. Use **Log in** with the same credentials to request a bearer token via
+   `POST /auth/login`. The UI stores the token in memory only.
+
+## Load account data
+
+1. Paste your account ID and submit **Load account**.
+2. The UI will fetch the latest balance (`GET /accounts/{id}/balance`) and the
+   25 most recent transactions (`GET /accounts/{id}/transactions`).
+3. Refresh the section any time with the **Reload** button.
+
+## Send a transfer
+
+1. Load an account and keep the session active (token present).
+2. Enter the destination account ID, amount, currency, and optional memo.
+3. Submit the form to trigger `POST /tx/transfer`. The UI generates an
+   idempotency key automatically and surfaces API errors inline.
+
+## Preview remittance quotes
+
+1. With an account loaded, open the **Preview quote** section.
+2. Choose a scenario (Default, Tariffed, Subsidized) and USD sell amount.
+3. Submit to call `POST /simulate/quote`. The response includes buy/sell amounts,
+   effective rate, and expiration timestamp.
+
+## Troubleshooting
+
+- **401 Unauthorized** – The bearer token may be expired. Log in again.
+- **404 Account not found** – Ensure the account ID matches one issued by the API.
+- **Transfer stuck** – Check the runbook for `POST /tx/transfer` guidance and
+  confirm the memo matches Merchant POS invoices when applicable.

--- a/docs/redoc.html
+++ b/docs/redoc.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>QZD API – Redoc</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        margin: 0;
+        font-family:
+          'Inter',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          sans-serif;
+      }
+      .topbar {
+        background: #0f172a;
+        color: #f8fafc;
+        padding: 0.75rem 1.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        position: sticky;
+        top: 0;
+        z-index: 10;
+      }
+      .topbar a {
+        color: inherit;
+        text-decoration: none;
+        font-weight: 600;
+      }
+      redoc {
+        height: calc(100vh - 56px);
+      }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+  </head>
+  <body>
+    <header class="topbar">
+      <span>QZD OpenAPI reference</span>
+      <a href="./index.html">Back to docs hub</a>
+    </header>
+    <redoc spec-url="./openapi.yaml"></redoc>
+  </body>
+</html>

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,56 @@
+# Operations Runbook
+
+This runbook maps operational procedures to the OpenAPI endpoints implemented in
+`apps/api`. Use it during incidents and routine maintenance.
+
+## Quick references
+
+| Scenario                   | Endpoints                                                                                   | Notes                                                                             |
+| -------------------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| API health check           | `GET /health/live`, `GET /health/ready`                                                     | Use `/health/live` for liveness and `/health/ready` before routing traffic.       |
+| Metrics scrape             | `GET /metrics`                                                                              | Prometheus scrape target exposed by the NestJS server.                            |
+| User onboarding outage     | `POST /auth/register`, `POST /accounts`, `POST /accounts/kyc`                               | Validate payloads and auth headers; see `apps/api/src/in-memory-bank.service.ts`. |
+| Login/auth token issues    | `POST /auth/login`                                                                          | Inspect JWT configuration and expiry handling.                                    |
+| Balance mismatch           | `GET /accounts/{id}/balance`, `GET /accounts/{id}/transactions`                             | Compare responses with ledger events in `packages/ledger`.                        |
+| Transfer stuck in pending  | `POST /tx/transfer`                                                                         | Ensure idempotency keys are unique and inspect error payloads.                    |
+| Issuance backlog           | `POST /tx/issue`, `GET /admin/issuance-requests`, `POST /admin/issuance-requests/{id}/sign` | Confirm validator quorum; retry signatures if the queue stalls.                   |
+| Voucher redemption failure | `POST /agents/cashin`, `POST /agents/cashout`, `POST /agents/vouchers/{code}/redeem`        | Check agent idempotency keys and voucher lifecycle fields.                        |
+| Remittance quote errors    | `POST /simulate/quote`, `POST /remit/us/acquire-qzd`                                        | Validate scenario flags and currency codes; align with wallet quote UI.           |
+| Alert ingestion            | `GET /admin/alerts`, `POST /admin/alerts/{id}/ack`                                          | Verify the admin console receives alerts and ack responses return 204.            |
+| SMS command errors         | `POST /sms/inbound`                                                                         | Use the SMS simulator (`pnpm --filter @qzd/sms-sim start`) to reproduce issues.   |
+
+## Standard operating procedures
+
+### 1. Confirm platform status
+
+1. Call `GET /health/live` and `GET /health/ready`.
+2. If `/health/ready` fails, inspect recent deployments and database connectivity.
+3. Review Prometheus at <http://localhost:9090> and Grafana at
+   <http://localhost:3001> when running via Docker Compose.
+
+### 2. Regenerate SDKs after contract updates
+
+1. Validate the contract with `pnpm oas:lint`.
+2. Run `pnpm gen:sdks` and `pnpm gen:types`.
+3. Execute `pnpm test:contract` to assert SDK compatibility against the Prism mock
+   server (`pnpm oas:mock`).
+4. Deploy updated packages to downstream applications.
+
+### 3. Recover from degraded cash operations
+
+1. Confirm agent API calls (`POST /agents/cashin`, `POST /agents/cashout`) are
+   returning 202 responses. Retry idempotent requests with new keys if 409s are
+   returned.
+2. Inspect vouchers via `POST /agents/vouchers/{code}/redeem`; a 404 indicates a
+   previously consumed or expired voucher.
+3. Coordinate with admin operators to clear issuance backlog via
+   `POST /admin/issuance-requests/{id}/sign`.
+
+### 4. Handle SMS command regressions
+
+1. Use the SMS simulator to send the failing command: `pnpm --filter @qzd/sms-sim start`.
+2. Trace the API handler at `/sms/inbound` and ensure responses include a `reply`
+   string.
+3. Compare behaviour against the OpenAPI example payloads in `openapi/openapi.yaml`.
+
+Document any novel remediation in this file so on-call engineers can repeat it.


### PR DESCRIPTION
## Summary
- add API workflow, architecture, runbook, contributor checklist, and actor manuals under `docs/`
- refresh the docs landing page and provide a dedicated Redoc view of the OpenAPI spec
- mount the OpenAPI spec into the `docs` service so Docker Compose serves the Redoc site

## Testing
- pnpm -r lint
- pnpm -r typecheck

------
https://chatgpt.com/codex/tasks/task_e_68db3f2c4d708330ad785e2287173931