### PR TITLE
chore: add Dockerfiles for app deployments

### DIFF
--- a/apps/admin-web/Dockerfile
+++ b/apps/admin-web/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.5
+FROM node:20-alpine AS base
+WORKDIR /workspace
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN apk add --no-cache libc6-compat python3 make g++ \
+  && corepack enable
+
+FROM base AS build
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/api/package.json apps/api/package.json
+COPY apps/admin-web/package.json apps/admin-web/package.json
+COPY apps/merchant-pos/package.json apps/merchant-pos/package.json
+COPY apps/sms-sim/package.json apps/sms-sim/package.json
+COPY apps/wallet-web/package.json apps/wallet-web/package.json
+COPY packages/card-mock/package.json packages/card-mock/package.json
+COPY packages/ledger/package.json packages/ledger/package.json
+COPY packages/sdk/package.json packages/sdk/package.json
+COPY packages/sdk-api/package.json packages/sdk-api/package.json
+COPY packages/sdk-browser/package.json packages/sdk-browser/package.json
+COPY packages/sdk-node/package.json packages/sdk-node/package.json
+COPY packages/shared/package.json packages/shared/package.json
+RUN pnpm fetch
+COPY . .
+RUN pnpm install --offline --frozen-lockfile
+ARG VITE_API_BASE_URL=/api
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+RUN pnpm --filter @qzd/admin-web build
+
+FROM nginx:1.25-alpine
+COPY apps/admin-web/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /workspace/apps/admin-web/dist /usr/share/nginx/html
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -q -O - http://127.0.0.1/healthz || exit 1

--- a/apps/admin-web/nginx.conf
+++ b/apps/admin-web/nginx.conf
@@ -1,0 +1,15 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+
+  location / {
+    try_files $uri /index.html;
+  }
+
+  location = /healthz {
+    access_log off;
+    add_header Content-Type text/plain;
+    return 200 'ok';
+  }
+}

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1.5
+FROM node:20-alpine AS base
+WORKDIR /workspace
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN apk add --no-cache libc6-compat python3 make g++ \
+  && corepack enable
+
+FROM base AS deps
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/api/package.json apps/api/package.json
+COPY apps/admin-web/package.json apps/admin-web/package.json
+COPY apps/merchant-pos/package.json apps/merchant-pos/package.json
+COPY apps/sms-sim/package.json apps/sms-sim/package.json
+COPY apps/wallet-web/package.json apps/wallet-web/package.json
+COPY packages/card-mock/package.json packages/card-mock/package.json
+COPY packages/ledger/package.json packages/ledger/package.json
+COPY packages/sdk/package.json packages/sdk/package.json
+COPY packages/sdk-api/package.json packages/sdk-api/package.json
+COPY packages/sdk-browser/package.json packages/sdk-browser/package.json
+COPY packages/sdk-node/package.json packages/sdk-node/package.json
+COPY packages/shared/package.json packages/shared/package.json
+RUN pnpm fetch
+COPY . .
+RUN pnpm install --offline --frozen-lockfile
+
+FROM deps AS build
+RUN pnpm --filter @qzd/api build
+RUN pnpm --filter @qzd/api deploy --prod --dest /app/api
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=8080
+COPY --from=build /app/api ./
+EXPOSE 8080
+CMD ["node", "dist/main.js"]

--- a/apps/merchant-pos/Dockerfile
+++ b/apps/merchant-pos/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.5
+FROM node:20-alpine AS base
+WORKDIR /workspace
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN apk add --no-cache libc6-compat python3 make g++ \
+  && corepack enable
+
+FROM base AS build
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/api/package.json apps/api/package.json
+COPY apps/admin-web/package.json apps/admin-web/package.json
+COPY apps/merchant-pos/package.json apps/merchant-pos/package.json
+COPY apps/sms-sim/package.json apps/sms-sim/package.json
+COPY apps/wallet-web/package.json apps/wallet-web/package.json
+COPY packages/card-mock/package.json packages/card-mock/package.json
+COPY packages/ledger/package.json packages/ledger/package.json
+COPY packages/sdk/package.json packages/sdk/package.json
+COPY packages/sdk-api/package.json packages/sdk-api/package.json
+COPY packages/sdk-browser/package.json packages/sdk-browser/package.json
+COPY packages/sdk-node/package.json packages/sdk-node/package.json
+COPY packages/shared/package.json packages/shared/package.json
+RUN pnpm fetch
+COPY . .
+RUN pnpm install --offline --frozen-lockfile
+ARG VITE_API_BASE_URL=/api
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+RUN pnpm --filter @qzd/merchant-pos build
+
+FROM nginx:1.25-alpine
+COPY apps/merchant-pos/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /workspace/apps/merchant-pos/dist /usr/share/nginx/html
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -q -O - http://127.0.0.1/healthz || exit 1

--- a/apps/merchant-pos/nginx.conf
+++ b/apps/merchant-pos/nginx.conf
@@ -1,0 +1,15 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+
+  location / {
+    try_files $uri /index.html;
+  }
+
+  location = /healthz {
+    access_log off;
+    add_header Content-Type text/plain;
+    return 200 'ok';
+  }
+}

--- a/apps/sms-sim/Dockerfile
+++ b/apps/sms-sim/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.5
+FROM node:20-alpine AS base
+WORKDIR /workspace
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN apk add --no-cache libc6-compat python3 make g++ \
+  && corepack enable
+
+FROM base AS build
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/api/package.json apps/api/package.json
+COPY apps/admin-web/package.json apps/admin-web/package.json
+COPY apps/merchant-pos/package.json apps/merchant-pos/package.json
+COPY apps/sms-sim/package.json apps/sms-sim/package.json
+COPY apps/wallet-web/package.json apps/wallet-web/package.json
+COPY packages/card-mock/package.json packages/card-mock/package.json
+COPY packages/ledger/package.json packages/ledger/package.json
+COPY packages/sdk/package.json packages/sdk/package.json
+COPY packages/sdk-api/package.json packages/sdk-api/package.json
+COPY packages/sdk-browser/package.json packages/sdk-browser/package.json
+COPY packages/sdk-node/package.json packages/sdk-node/package.json
+COPY packages/shared/package.json packages/shared/package.json
+RUN pnpm fetch
+COPY . .
+RUN pnpm install --offline --frozen-lockfile
+RUN pnpm --filter @qzd/sms-sim deploy --prod --dest /app/sms-sim
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/sms-sim ./
+ENTRYPOINT ["node", "src/index.mjs"]

--- a/apps/wallet-web/Dockerfile
+++ b/apps/wallet-web/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.5
+FROM node:20-alpine AS base
+WORKDIR /workspace
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN apk add --no-cache libc6-compat python3 make g++ \
+  && corepack enable
+
+FROM base AS build
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/api/package.json apps/api/package.json
+COPY apps/admin-web/package.json apps/admin-web/package.json
+COPY apps/merchant-pos/package.json apps/merchant-pos/package.json
+COPY apps/sms-sim/package.json apps/sms-sim/package.json
+COPY apps/wallet-web/package.json apps/wallet-web/package.json
+COPY packages/card-mock/package.json packages/card-mock/package.json
+COPY packages/ledger/package.json packages/ledger/package.json
+COPY packages/sdk/package.json packages/sdk/package.json
+COPY packages/sdk-api/package.json packages/sdk-api/package.json
+COPY packages/sdk-browser/package.json packages/sdk-browser/package.json
+COPY packages/sdk-node/package.json packages/sdk-node/package.json
+COPY packages/shared/package.json packages/shared/package.json
+RUN pnpm fetch
+COPY . .
+RUN pnpm install --offline --frozen-lockfile
+ARG VITE_API_BASE_URL=/api
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+RUN pnpm --filter @qzd/wallet-web build
+
+FROM nginx:1.25-alpine
+COPY apps/wallet-web/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /workspace/apps/wallet-web/dist /usr/share/nginx/html
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -q -O - http://127.0.0.1/healthz || exit 1

--- a/apps/wallet-web/nginx.conf
+++ b/apps/wallet-web/nginx.conf
@@ -1,0 +1,15 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+
+  location / {
+    try_files $uri /index.html;
+  }
+
+  location = /healthz {
+    access_log off;
+    add_header Content-Type text/plain;
+    return 200 'ok';
+  }
+}


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfiles for the API, SPA front-ends, and SMS simulator
- provide SPA nginx configurations with health endpoints for containerized hosting

## Testing
- pnpm -r lint
- pnpm -r typecheck

------
https://chatgpt.com/codex/tasks/task_e_68db6594077883308f34b4c26899da96