### PR TITLE
chore(ci): add release automation workflows

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,55 @@
+name: Post Release
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  tag-release:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Determine release tag
+        id: tag
+        shell: bash
+        run: |
+          set -eo pipefail
+          REF="${{ github.event.pull_request.head.ref }}"
+          TITLE="${{ github.event.pull_request.title }}"
+          if [[ "$REF" == release/* ]]; then
+            TAG="${REF#release/}"
+          elif [[ "$TITLE" =~ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+            TAG="v${BASH_REMATCH[1]}"
+          else
+            echo "Unable to determine release tag from PR metadata." >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Push git tag
+        shell: bash
+        run: |
+          set -eo pipefail
+          TAG="${{ steps.tag.outputs.tag }}"
+          if git rev-parse -q --verify "refs/tags/$TAG"; then
+            echo "Tag $TAG already exists; skipping." >&2
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "${{ github.event.repository.default_branch }}" --prune --tags
+          git checkout "${{ github.event.repository.default_branch }}"
+          git pull origin "${{ github.event.repository.default_branch }}"
+          COMMIT=$(git rev-parse HEAD)
+          git tag -a "$TAG" "$COMMIT" -m "Release $TAG"
+          git push origin "$TAG"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,61 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_target:
+        description: 'Release version (e.g. 1.2.3) or semver bump (major, minor, patch)'
+        required: true
+        default: patch
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    name: Prepare release branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: pnpm
+
+      - name: Calculate next version
+        id: bump
+        run: |
+          VERSION=$(node scripts/bump-version.mjs "${{ inputs.release_target }}")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Generate changelog
+        run: |
+          pnpm dlx conventional-changelog-cli -p angular -i CHANGELOG.md -s -r 0
+
+      - name: Create release pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore(release): v${{ steps.bump.outputs.version }}'
+          branch: 'release/v${{ steps.bump.outputs.version }}'
+          base: ${{ github.event.repository.default_branch }}
+          title: 'chore(release): v${{ steps.bump.outputs.version }}'
+          labels: release
+          body: |
+            ## Summary
+            - prepare release v${{ steps.bump.outputs.version }}
+            - update package versions and changelog
+
+            ---
+            _Automated release preparation._

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const IGNORE_DIRS = new Set([
+  '.git',
+  '.github',
+  '.husky',
+  'node_modules',
+  'dist',
+  'build',
+  '.turbo',
+  '.next',
+  '.output',
+  '.vercel',
+  'coverage',
+  '.pnpm',
+]);
+
+function collectPackageJson(startDir) {
+  const files = [];
+  const queue = [startDir];
+  while (queue.length > 0) {
+    const current = queue.pop();
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (IGNORE_DIRS.has(entry.name)) continue;
+        if (entry.name.startsWith('.')) {
+          // Skip hidden directories to avoid scanning configuration folders
+          continue;
+        }
+        queue.push(path.join(current, entry.name));
+      } else if (entry.isFile() && entry.name === 'package.json') {
+        files.push(path.join(current, entry.name));
+      }
+    }
+  }
+  return files.sort((a, b) => a.localeCompare(b));
+}
+
+function parseSemver(input) {
+  const match = input.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`Invalid semantic version: ${input}`);
+  }
+  return match.slice(1).map((value) => Number.parseInt(value, 10));
+}
+
+function bumpVersion(baseVersion, releaseTarget) {
+  if (['major', 'minor', 'patch'].includes(releaseTarget)) {
+    const [major, minor, patch] = parseSemver(baseVersion);
+    switch (releaseTarget) {
+      case 'major':
+        return `${major + 1}.0.0`;
+      case 'minor':
+        return `${major}.${minor + 1}.0`;
+      case 'patch':
+        return `${major}.${minor}.${patch + 1}`;
+    }
+  }
+
+  // if we reach here, the target must be an explicit version string
+  const nextVersion = releaseTarget.startsWith('v') ? releaseTarget.slice(1) : releaseTarget;
+  const [nextMajor, nextMinor, nextPatch] = parseSemver(nextVersion);
+  const [baseMajor, baseMinor, basePatch] = parseSemver(baseVersion);
+
+  const isGreater =
+    nextMajor > baseMajor ||
+    (nextMajor === baseMajor && nextMinor > baseMinor) ||
+    (nextMajor === baseMajor && nextMinor === baseMinor && nextPatch > basePatch);
+
+  if (!isGreater) {
+    throw new Error(
+      `Provided version (${nextVersion}) must be greater than current (${baseVersion}).`,
+    );
+  }
+
+  return `${nextMajor}.${nextMinor}.${nextPatch}`;
+}
+
+function updatePackageVersion(filePath, newVersion) {
+  const contents = readFileSync(filePath, 'utf8');
+  let data;
+  try {
+    data = JSON.parse(contents);
+  } catch (error) {
+    throw new Error(`Unable to parse ${filePath}: ${error.message}`);
+  }
+  if (!Object.prototype.hasOwnProperty.call(data, 'version')) {
+    return false;
+  }
+  data.version = newVersion;
+  writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+  return true;
+}
+
+function main() {
+  const releaseTarget = process.argv[2];
+  if (!releaseTarget) {
+    console.error('Usage: node scripts/bump-version.mjs <version|major|minor|patch>');
+    process.exit(1);
+  }
+
+  const repoRoot = process.cwd();
+  const rootPackagePath = path.join(repoRoot, 'package.json');
+  const rootContents = readFileSync(rootPackagePath, 'utf8');
+  const rootJson = JSON.parse(rootContents);
+  const currentVersion = rootJson.version;
+
+  const newVersion = bumpVersion(currentVersion, releaseTarget);
+
+  const packageFiles = collectPackageJson(repoRoot);
+  let updatedCount = 0;
+  for (const file of packageFiles) {
+    if (updatePackageVersion(file, newVersion)) {
+      updatedCount += 1;
+    }
+  }
+
+  if (updatedCount === 0) {
+    console.error('No package.json files were updated.');
+    process.exit(1);
+  }
+
+  console.error(`Updated ${updatedCount} package.json files to version ${newVersion}.`);
+  console.log(newVersion);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a manual release preparation workflow that bumps versions, regenerates the changelog, and opens a release PR
- add a post-release workflow that tags the default branch when release PRs are merged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc0ba7cd84833092be936044c6a8e5