### PR TITLE
chore(ci): install deps in release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -33,6 +33,9 @@ jobs:
           node-version: 18
           cache: pnpm
 
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Calculate next version
         id: bump
         run: |


### PR DESCRIPTION
## Summary
- install workspace dependencies in the prepare-release workflow so husky lint/typecheck hooks succeed

## Testing
- pnpm -r lint
- pnpm -r typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc0fb4bc0c8330ab561947ef879e10