### PR TITLE
chore(ci): ensure publish images runs for release tags

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -12,6 +12,9 @@ jobs:
   tag-release:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      created: ${{ steps.push_tag.outputs.created }}
     steps:
       - name: Checkout default branch
         uses: actions/checkout@v4
@@ -37,12 +40,14 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Push git tag
+        id: push_tag
         shell: bash
         run: |
           set -eo pipefail
           TAG="${{ steps.tag.outputs.tag }}"
           if git rev-parse -q --verify "refs/tags/$TAG"; then
             echo "Tag $TAG already exists; skipping." >&2
+            echo "created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git config user.name "github-actions[bot]"
@@ -53,3 +58,12 @@ jobs:
           COMMIT=$(git rev-parse HEAD)
           git tag -a "$TAG" "$COMMIT" -m "Release $TAG"
           git push origin "$TAG"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+  publish-images:
+    needs: tag-release
+    if: needs.tag-release.outputs.tag != '' && needs.tag-release.outputs.created == 'true'
+    uses: ./.github/workflows/publish-images.yml
+    with:
+      tag: ${{ needs.tag-release.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - '*'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Git tag to build images for'
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -36,8 +42,23 @@ jobs:
             dockerfile: apps/sms-sim/Dockerfile
 
     steps:
+      - name: Determine tag reference
+        id: tag
+        shell: bash
+        run: |
+          set -eo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_call" ]]; then
+            echo "name=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "ref=refs/tags/${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "ref=${GITHUB_REF}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.ref }}
 
       - name: Normalize owner name
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
@@ -58,7 +79,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.IMAGE_PREFIX }}-${{ matrix.component }}
           tags: |
-            type=ref,event=tag
+            type=raw,value=${{ steps.tag.outputs.name }}
             type=raw,value=latest
 
       - name: Build and push image


### PR DESCRIPTION
## Summary
- allow the publish-images workflow to run via workflow_call and explicitly resolve tag refs
- trigger the publish-images workflow from the post-release automation once a tag is created

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68dc29fc143883309fd3c85bb1388140