### PR TITLE
fix: enable post-release workflow to publish images

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   tag-release:


### PR DESCRIPTION
## Summary
- grant the post-release workflow packages: write permissions so it can call publish-images

## Testing
- pnpm -r lint
- pnpm -r typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc2de8cd24833095f2576ff0ab63f1