### PR TITLE
fix: use repo root context for image builds

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -26,19 +26,19 @@ jobs:
       matrix:
         include:
           - component: api
-            context: apps/api
+            context: .
             dockerfile: apps/api/Dockerfile
           - component: wallet-web
-            context: apps/wallet-web
+            context: .
             dockerfile: apps/wallet-web/Dockerfile
           - component: admin-web
-            context: apps/admin-web
+            context: .
             dockerfile: apps/admin-web/Dockerfile
           - component: merchant-pos
-            context: apps/merchant-pos
+            context: .
             dockerfile: apps/merchant-pos/Dockerfile
           - component: sms-sim
-            context: apps/sms-sim
+            context: .
             dockerfile: apps/sms-sim/Dockerfile
 
     steps:


### PR DESCRIPTION
## Summary
- use the repository root as the Docker build context for all publish-images jobs so workspace package manifests are available during COPY steps

## Testing
- pnpm -r lint
- pnpm -r typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc309f14ec8330a9bf8d2f54df4f52