### PR TITLE
fix: adjust pnpm deploy syntax for docker builds

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -26,7 +26,7 @@ RUN pnpm install --offline --frozen-lockfile
 
 FROM deps AS build
 RUN pnpm --filter @qzd/api build
-RUN pnpm --filter @qzd/api deploy --prod --dest /app/api
+RUN pnpm --filter @qzd/api deploy --prod /app/api
 
 FROM node:20-alpine AS runner
 WORKDIR /app

--- a/apps/sms-sim/Dockerfile
+++ b/apps/sms-sim/Dockerfile
@@ -23,7 +23,7 @@ COPY packages/shared/package.json packages/shared/package.json
 RUN pnpm fetch
 COPY . .
 RUN pnpm install --offline --frozen-lockfile
-RUN pnpm --filter @qzd/sms-sim deploy --prod --dest /app/sms-sim
+RUN pnpm --filter @qzd/sms-sim deploy --prod /app/sms-sim
 
 FROM node:20-alpine
 WORKDIR /app


### PR DESCRIPTION
## Summary
- update the API and SMS simulator Dockerfiles to pass the deploy destination as a positional argument compatible with pnpm 8

## Testing
- pnpm --filter @qzd/sms-sim deploy --prod /tmp/sms-sim-test
- pnpm -r lint
- pnpm -r typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc3340fcc48330a35d36003fca1a02