### PR TITLE
fix: ensure merchant POS build generates SDK outputs

### DIFF
--- a/apps/merchant-pos/package.json
+++ b/apps/merchant-pos/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "pnpm gen:sdks && pnpm --filter @qzd/sdk-api build && pnpm --filter @qzd/sdk-browser build",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- ensure the merchant POS build step generates SDK artifacts before bundling so Vite can resolve @qzd/sdk-browser

## Testing
- pnpm --filter @qzd/merchant-pos build

------
https://chatgpt.com/codex/tasks/task_e_68dc35f38f308330a20ee88ae1acb52a