### PR TITLE
fix: build SDK packages before web app bundles

### DIFF
--- a/apps/admin-web/package.json
+++ b/apps/admin-web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "pnpm --filter @qzd/sdk-browser run build && vite build",
     "preview": "vite preview",
     "test": "vitest run",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",

--- a/apps/wallet-web/package.json
+++ b/apps/wallet-web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "pnpm --filter @qzd/sdk-browser run build && vite build",
     "preview": "vite preview",
     "test": "vitest run",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",

--- a/packages/sdk-api/package.json
+++ b/packages/sdk-api/package.json
@@ -39,8 +39,7 @@
   ],
   "scripts": {
     "generate": "pnpm --dir ../../ run gen:sdks",
-    "prebuild": "pnpm run generate",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "pnpm run generate && tsc -p tsconfig.build.json",
     "lint": "eslint --no-warn-ignored \"src/**/*.ts\" --ignore-pattern \"src/**/generated/**\"",
     "typecheck": "node ../../scripts/ensure-sdk-api-generated.mjs && tsc --noEmit"
   },

--- a/packages/sdk-browser/package.json
+++ b/packages/sdk-browser/package.json
@@ -14,8 +14,7 @@
     "dist"
   ],
   "scripts": {
-    "prebuild": "pnpm --filter @qzd/sdk-api build",
-    "build": "tsup src/index.ts --dts --format esm --out-dir dist --clean",
+    "build": "pnpm --filter @qzd/sdk-api run build && tsup src/index.ts --dts --format esm --out-dir dist --clean",
     "test": "vitest run",
     "test:contract": "vitest run tests/contract.test.ts",
     "lint": "eslint --no-warn-ignored \"src/**/*.ts\"",


### PR DESCRIPTION
## Summary
- ensure the admin and wallet web builds compile the shared browser SDK before invoking Vite
- have the browser SDK build drive the SDK API build so generated dist files exist when bundling
- run the SDK API generator before compiling to keep its build output in sync with the OpenAPI spec

## Testing
- pnpm --filter @qzd/admin-web build
- pnpm --filter @qzd/wallet-web build

------
https://chatgpt.com/codex/tasks/task_e_68dc5f1e73b48330818d98c989b1e1f8