### PR TITLE
fix(api): build workspace deps before compile

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "prebuild": "pnpm --filter @qzd/ledger build && pnpm --filter @qzd/sdk-api build",
-    "build": "tsc -p tsconfig.build.json",
+    "prebuild": "pnpm --filter @qzd/shared build && pnpm --filter @qzd/card-mock build && pnpm --filter @qzd/ledger build && pnpm --filter @qzd/sdk-api build",
+    "build": "pnpm run prebuild && tsc -p tsconfig.build.json",
     "start": "node dist/main.js",
     "dev": "node --loader ts-node/esm --experimental-specifier-resolution=node src/main.ts",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- extend the API prebuild script to build shared, card-mock, ledger, and sdk-api packages
- call the prebuild step from the build script so filtered builds compile against fresh artifacts

## Testing
- pnpm --filter @qzd/api build

------
https://chatgpt.com/codex/tasks/task_e_68dc62c7076883308c9b8625084aebbf