### PR TITLE
fix: ensure merchant-pos builds against local sdk sources

### DIFF
--- a/apps/merchant-pos/package.json
+++ b/apps/merchant-pos/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "prebuild": "pnpm gen:sdks && pnpm --filter @qzd/sdk-api build && pnpm --filter @qzd/sdk-browser build",
-    "build": "vite build",
+    "build": "pnpm --filter @qzd/sdk-browser run build && vite build",
     "preview": "vite preview",
     "test": "vitest run",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",

--- a/apps/merchant-pos/vite.config.ts
+++ b/apps/merchant-pos/vite.config.ts
@@ -1,6 +1,20 @@
 import { defineConfig } from 'vite';
+import { fileURLToPath } from 'node:url';
 import react from '@vitejs/plugin-react';
+
+const projectRoot = new URL('.', import.meta.url);
+const sdkBrowserEntry = fileURLToPath(new URL('../../packages/sdk-browser/src/index.ts', projectRoot));
+const sdkApiBrowserEntry = fileURLToPath(new URL('../../packages/sdk-api/src/browser/index.ts', projectRoot));
+const sdkApiBrowserDir = fileURLToPath(new URL('../../packages/sdk-api/src/browser', projectRoot));
+const sdkApiBrowserDirWithSlash = sdkApiBrowserDir.endsWith('/') ? sdkApiBrowserDir : `${sdkApiBrowserDir}/`;
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: [
+      { find: '@qzd/sdk-browser', replacement: sdkBrowserEntry },
+      { find: /^@qzd\/sdk-api\/browser$/, replacement: sdkApiBrowserEntry },
+      { find: /^@qzd\/sdk-api\/browser\/(.*)$/, replacement: `${sdkApiBrowserDirWithSlash}$1` }
+    ]
+  }
 });


### PR DESCRIPTION
## Summary
- add Vite aliases in merchant POS so the browser SDK resolves to the workspace sources during builds
- update the merchant POS build script to compile the browser SDK before running Vite

## Testing
- pnpm --filter @qzd/merchant-pos build

------
https://chatgpt.com/codex/tasks/task_e_68dc65ff4f508330a8e86343dff7ad22