### PR TITLE
fix: install jre for openapi generation

### DIFF
--- a/apps/admin-web/Dockerfile
+++ b/apps/admin-web/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine AS base
 WORKDIR /workspace
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN apk add --no-cache libc6-compat python3 make g++ \
+RUN apk add --no-cache libc6-compat python3 make g++ openjdk17-jre-headless \
   && corepack enable
 
 FROM base AS build

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine AS base
 WORKDIR /workspace
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN apk add --no-cache libc6-compat python3 make g++ \
+RUN apk add --no-cache libc6-compat python3 make g++ openjdk17-jre-headless \
   && corepack enable
 
 FROM base AS deps

--- a/apps/merchant-pos/Dockerfile
+++ b/apps/merchant-pos/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine AS base
 WORKDIR /workspace
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN apk add --no-cache libc6-compat python3 make g++ \
+RUN apk add --no-cache libc6-compat python3 make g++ openjdk17-jre-headless \
   && corepack enable
 
 FROM base AS build

--- a/apps/sms-sim/Dockerfile
+++ b/apps/sms-sim/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine AS base
 WORKDIR /workspace
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN apk add --no-cache libc6-compat python3 make g++ \
+RUN apk add --no-cache libc6-compat python3 make g++ openjdk17-jre-headless \
   && corepack enable
 
 FROM base AS build

--- a/apps/wallet-web/Dockerfile
+++ b/apps/wallet-web/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-alpine AS base
 WORKDIR /workspace
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN apk add --no-cache libc6-compat python3 make g++ \
+RUN apk add --no-cache libc6-compat python3 make g++ openjdk17-jre-headless \
   && corepack enable
 
 FROM base AS build


### PR DESCRIPTION
## Summary
- add OpenJDK 17 to each Node-based Docker build stage so the OpenAPI generator can run during pnpm builds

## Testing
- `pnpm -r lint`
- `pnpm -r typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68dc6a0139d4833084972103a4296a1b