### PR TITLE
chore(ci): add spec governance workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,39 @@ on:
     branches: ["main"]
 
 jobs:
+  spec-governance:
+    name: Spec Governance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8.15.4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install oasdiff
+        run: |
+          mkdir -p "$HOME/go/bin"
+          GOBIN="$HOME/go/bin" go install github.com/oasdiff/oasdiff@v1.11.7
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+      - name: Lint OpenAPI specification
+        run: pnpm oas:lint
+      - name: Check for OpenAPI breaking changes
+        run: ./scripts/check-openapi-breaking.sh origin/main
+
   build:
     runs-on: ubuntu-latest
+    needs:
+      - spec-governance
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/scripts/check-openapi-breaking.sh
+++ b/scripts/check-openapi-breaking.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+SPEC_PATH="openapi/openapi.yaml"
+
+if ! command -v oasdiff >/dev/null 2>&1; then
+  echo "Error: oasdiff is required but was not found in PATH." >&2
+  echo "Install oasdiff (https://github.com/oasdiff/oasdiff) before running this check." >&2
+  exit 1
+fi
+
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "Fetching $BASE_REF from origin..."
+  git fetch origin "${BASE_REF#origin/}" --depth=1 >/dev/null 2>&1 || {
+    echo "Error: unable to fetch $BASE_REF" >&2
+    exit 1
+  }
+fi
+
+TMP_BASE_SPEC="$(mktemp)"
+trap 'rm -f "$TMP_BASE_SPEC"' EXIT
+
+if ! git show "${BASE_REF}:${SPEC_PATH}" >"$TMP_BASE_SPEC" 2>/dev/null; then
+  echo "Error: failed to read ${SPEC_PATH} from ${BASE_REF}." >&2
+  exit 1
+fi
+
+echo "Checking for breaking OpenAPI changes against ${BASE_REF}..."
+set +e
+BREAKING_OUTPUT="$(oasdiff breaking --format text "$TMP_BASE_SPEC" "$SPEC_PATH" 2>&1)"
+STATUS=$?
+set -e
+
+if [ $STATUS -eq 0 ]; then
+  if [ -n "$BREAKING_OUTPUT" ]; then
+    echo "$BREAKING_OUTPUT"
+  else
+    echo "No breaking changes detected."
+  fi
+else
+  if [ -n "$BREAKING_OUTPUT" ]; then
+    echo "$BREAKING_OUTPUT"
+  fi
+  echo ""
+  echo "Breaking OpenAPI changes detected compared to ${BASE_REF}." >&2
+fi
+
+exit $STATUS


### PR DESCRIPTION
## Summary
- add a spec governance workflow that lints the OpenAPI contract and checks for breaking changes against main before other jobs run
- add a reusable script that wraps oasdiff to report human-readable breaking-change results

## Testing
- ./scripts/check-openapi-breaking.sh HEAD
- pnpm oas:lint


------
https://chatgpt.com/codex/tasks/task_e_68dd5d3a2f448330a9a5156c6ea77c88