### PR TITLE
Add admin issuance e2e coverage

### DIFF
--- a/apps/api/src/admin-issuance.e2e.spec.ts
+++ b/apps/api/src/admin-issuance.e2e.spec.ts
@@ -1,0 +1,215 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { AppModule } from './app.module.js';
+import {
+  InMemoryBankService,
+  getFallbackBankService,
+  resetFallbackBankService,
+} from './in-memory-bank.service.js';
+import {
+  DEV_SIGNING_PUBLIC_KEY_HEX,
+  applySecurity,
+  createTestClient,
+  getResponseBody,
+  type TestClient,
+} from './test-helpers/request-security.js';
+
+type InternalAccountRecord = {
+  id: string;
+  balance: number;
+  openingBalance: number;
+  currency: string;
+};
+
+type InternalTransactionRecord = {
+  id?: string;
+  type?: string;
+  amount?: { value?: string; currency?: string };
+  metadata?: Record<string, string>;
+};
+
+type BankInternals = {
+  accounts: Map<string, InternalAccountRecord>;
+  transactions: Map<string, InternalTransactionRecord[]>;
+  computeAccountBalanceFromHistory(account: InternalAccountRecord): number;
+};
+
+describe('Admin issuance approvals', () => {
+  let app: INestApplication;
+  let server: ReturnType<INestApplication['getHttpServer']>;
+  let bank: InMemoryBankService;
+
+  beforeAll(async () => {
+    process.env.QZD_REQUEST_SIGNING_PUBLIC_KEY = DEV_SIGNING_PUBLIC_KEY_HEX;
+    resetFallbackBankService();
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    server = app.getHttpServer();
+    bank = getFallbackBankService();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    delete process.env.QZD_REQUEST_SIGNING_PUBLIC_KEY;
+  });
+
+  it('processes a multi-signature issuance and preserves ledger invariants', async () => {
+    const client = (): TestClient => createTestClient(server);
+    const email = `treasury${Date.now()}@example.com`;
+    const password = 'Pass1234!';
+    const fullName = 'Treasury Operator';
+
+    const registerBody = { email, password, fullName };
+    const { request: registerRequest } = applySecurity(
+      client().post('/auth/register'),
+      'POST',
+      '/auth/register',
+      registerBody,
+    );
+    const registerResponse = await registerRequest.send(registerBody).expect(201);
+    const registerPayload = getResponseBody<{
+      token?: string;
+      account?: { id?: string };
+    }>(registerResponse);
+
+    const token = registerPayload.token as string;
+    expect(token).toBeTruthy();
+    const accountId = registerPayload.account?.id as string;
+    expect(accountId).toBeTruthy();
+
+    const balanceResponse = await client()
+      .get(`/accounts/${accountId}/balance`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    const balancePayload = getResponseBody<{ total?: { value?: string } }>(balanceResponse);
+    const startingBalance = Number.parseFloat(balancePayload.total?.value ?? '0');
+
+    const bankInternals = bank as unknown as BankInternals;
+    const initialAccountRecord = bankInternals.accounts.get(accountId);
+    expect(initialAccountRecord).toBeDefined();
+    const totalBeforeIssuance = Array.from(bankInternals.accounts.values()).reduce(
+      (sum, record) => sum + record.balance,
+      0,
+    );
+
+    const issuanceAmountValue = '250.00';
+    const createIssuanceBody = {
+      accountId,
+      amount: { currency: 'QZD', value: issuanceAmountValue },
+      reference: 'Treasury top-up',
+    } as const;
+    const { request: createIssuanceRequest } = applySecurity(
+      client().post('/admin/issuance-requests'),
+      'POST',
+      '/admin/issuance-requests',
+      createIssuanceBody,
+    );
+    const issuanceResponse = await createIssuanceRequest
+      .set('Authorization', `Bearer ${token}`)
+      .send(createIssuanceBody)
+      .expect(201);
+    const issuancePayload = getResponseBody<{
+      id?: string;
+      status?: string;
+      required?: number;
+      collected?: number;
+    }>(issuanceResponse);
+
+    const issuanceId = issuancePayload.id as string;
+    expect(issuanceId).toMatch(/^ir_/);
+    expect(issuancePayload.required).toBe(2);
+    expect(issuancePayload.status).toBe('pending');
+    expect(issuancePayload.collected).toBe(0);
+
+    const firstSignatureBody = { validatorId: 'validator-1' } as const;
+    const firstSignaturePath = `/admin/issuance-requests/${issuanceId}/sign`;
+    const { request: firstSignatureRequest } = applySecurity(
+      client().post(firstSignaturePath),
+      'POST',
+      firstSignaturePath,
+      firstSignatureBody,
+    );
+    const firstSignatureResponse = await firstSignatureRequest
+      .set('Authorization', `Bearer ${token}`)
+      .send(firstSignatureBody);
+    expect([200, 201]).toContain(firstSignatureResponse.status);
+    const firstSignaturePayload = getResponseBody<{ collected?: number; status?: string }>(
+      firstSignatureResponse,
+    );
+    expect(firstSignaturePayload.collected).toBe(1);
+    expect(firstSignaturePayload.status).toBe('collecting');
+
+    const secondSignatureBody = { validatorId: 'validator-2' } as const;
+    const { request: secondSignatureRequest } = applySecurity(
+      client().post(firstSignaturePath),
+      'POST',
+      firstSignaturePath,
+      secondSignatureBody,
+    );
+    const secondSignatureResponse = await secondSignatureRequest
+      .set('Authorization', `Bearer ${token}`)
+      .send(secondSignatureBody);
+    expect([200, 201]).toContain(secondSignatureResponse.status);
+    const secondSignaturePayload = getResponseBody<{ collected?: number; status?: string }>(
+      secondSignatureResponse,
+    );
+    expect(secondSignaturePayload.collected).toBe(2);
+    expect(secondSignaturePayload.status).toBe('ready');
+
+    const finalizeBody = { requestId: issuanceId } as const;
+    const { request: finalizeRequest } = applySecurity(
+      client().post('/tx/issue'),
+      'POST',
+      '/tx/issue',
+      finalizeBody,
+    );
+    const finalizeResponse = await finalizeRequest
+      .set('Authorization', `Bearer ${token}`)
+      .send(finalizeBody);
+    expect([200, 201]).toContain(finalizeResponse.status);
+    const finalizePayload = getResponseBody<{
+      id?: string;
+      type?: string;
+      amount?: { value?: string };
+      metadata?: Record<string, string>;
+    }>(finalizeResponse);
+
+    expect(finalizePayload.type).toBe('issuance');
+    expect(finalizePayload.metadata?.requestId).toBe(issuanceId);
+    const mintedAmount = Number.parseFloat(finalizePayload.amount?.value ?? '0');
+    expect(mintedAmount).toBeCloseTo(Number.parseFloat(issuanceAmountValue), 2);
+
+    const balanceAfterResponse = await client()
+      .get(`/accounts/${accountId}/balance`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    const balanceAfterPayload = getResponseBody<{ total?: { value?: string } }>(
+      balanceAfterResponse,
+    );
+    const balanceAfter = Number.parseFloat(balanceAfterPayload.total?.value ?? '0');
+    expect(balanceAfter).toBeCloseTo(startingBalance + mintedAmount, 2);
+
+    const totalAfterIssuance = Array.from(bankInternals.accounts.values()).reduce(
+      (sum, record) => sum + record.balance,
+      0,
+    );
+    expect(totalAfterIssuance).toBeCloseTo(totalBeforeIssuance + mintedAmount, 2);
+
+    const updatedAccountRecord = bankInternals.accounts.get(accountId);
+    expect(updatedAccountRecord).toBeDefined();
+    const computeAccountBalanceFromHistory =
+      bankInternals.computeAccountBalanceFromHistory.bind(bankInternals);
+    const recomputedBalance = computeAccountBalanceFromHistory(updatedAccountRecord!);
+    expect(recomputedBalance).toBeCloseTo(updatedAccountRecord!.balance, 2);
+
+    const history = bankInternals.transactions.get(accountId) ?? [];
+    expect(history[0]?.type).toBe('issuance');
+    expect(history[0]?.metadata?.requestId).toBe(issuanceId);
+  });
+});

--- a/apps/api/src/admin-issuance.e2e.spec.ts
+++ b/apps/api/src/admin-issuance.e2e.spec.ts
@@ -13,7 +13,7 @@ import {
   createTestClient,
   getResponseBody,
   type TestClient,
-} from './test-helpers/request-security.js';
+} from './test-helpers/e2e-utils.js';
 
 type InternalAccountRecord = {
   id: string;

--- a/apps/api/src/flows.e2e.spec.ts
+++ b/apps/api/src/flows.e2e.spec.ts
@@ -15,7 +15,7 @@ import {
   type ErrorPayload,
   type SecurityOverrides,
   type TestClient,
-} from './test-helpers/request-security.js';
+} from './test-helpers/e2e-utils.js';
 
 describe('Wallet flows', () => {
   let app: INestApplication;

--- a/apps/api/src/test-helpers/request-security.ts
+++ b/apps/api/src/test-helpers/request-security.ts
@@ -1,0 +1,118 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import supertest from 'supertest';
+import { ed25519 } from '@noble/curves/ed25519';
+import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
+import {
+  createSignaturePayloadFromComponents as createSignaturePayload,
+  serializeBody,
+} from '@qzd/shared/request-security';
+
+type HeaderValue = string | number | readonly string[];
+
+type ResponseWithBody = { status: number; body: Record<string, unknown> };
+
+type ChainableTest = supertest.Test &
+  PromiseLike<ResponseWithBody> & {
+    set(field: string, value: HeaderValue): ChainableTest;
+    set(fields: Record<string, HeaderValue>): ChainableTest;
+    send(body?: unknown): ChainableTest;
+  };
+
+type TestClient = { post(path: string): ChainableTest; get(path: string): ChainableTest };
+
+type SecurityOverrides = {
+  idempotencyKey?: string;
+  nonce?: string;
+};
+
+interface SecurityHeaders {
+  idempotencyKey: string;
+  nonce: string;
+  signature: string;
+}
+
+const DEV_SIGNING_PRIVATE_KEY_HEX =
+  '0a3c8c97f7925ea37e46f69af43e219b1d09de89ec1a76cf2ce9a9289a392d5a';
+
+const DEV_SIGNING_PUBLIC_KEY_HEX = bytesToHex(
+  ed25519.getPublicKey(hexToBytes(DEV_SIGNING_PRIVATE_KEY_HEX)),
+);
+
+function buildSecurityHeaders(
+  method: string,
+  path: string,
+  body: unknown,
+  overrides: SecurityOverrides = {},
+): SecurityHeaders {
+  const idempotencyKey = overrides.idempotencyKey ?? `idem-${randomUUID()}`;
+  const nonce = overrides.nonce ?? bytesToHex(randomBytes(16));
+  const serializedBody = serializeBody(body);
+  const payload = createSignaturePayload({
+    method,
+    path,
+    idempotencyKey,
+    nonce,
+    serializedBody,
+  });
+  const signature = bytesToHex(ed25519.sign(payload, hexToBytes(DEV_SIGNING_PRIVATE_KEY_HEX)));
+  return { idempotencyKey, nonce, signature };
+}
+
+function applySecurity(
+  request: ChainableTest,
+  method: string,
+  path: string,
+  body: unknown,
+  overrides: SecurityOverrides = {},
+): { request: ChainableTest; headers: SecurityHeaders } {
+  const headers = buildSecurityHeaders(method, path, body, overrides);
+  request
+    .set('Idempotency-Key', headers.idempotencyKey)
+    .set('X-QZD-Nonce', headers.nonce)
+    .set('X-QZD-Signature', headers.signature);
+  return { request, headers };
+}
+
+function createTestClient(server: Parameters<typeof supertest>[0]): TestClient {
+  return supertest(server) as unknown as TestClient;
+}
+
+function getResponseBody<T extends Record<string, unknown>>(response: ResponseWithBody): T {
+  return response.body as T;
+}
+
+type ErrorPayload = {
+  code?: string;
+  message?: { code?: string; message?: string } | string;
+};
+
+function extractErrorDetails(payload: ErrorPayload): { code?: string; message?: string } {
+  if (typeof payload.message === 'object' && payload.message) {
+    return {
+      code: payload.message.code ?? payload.code,
+      message: payload.message.message,
+    };
+  }
+
+  return {
+    code: payload.code,
+    message: typeof payload.message === 'string' ? payload.message : undefined,
+  };
+}
+
+export {
+  applySecurity,
+  buildSecurityHeaders,
+  createTestClient,
+  extractErrorDetails,
+  getResponseBody,
+  DEV_SIGNING_PUBLIC_KEY_HEX,
+};
+export type {
+  ChainableTest,
+  ErrorPayload,
+  ResponseWithBody,
+  SecurityHeaders,
+  SecurityOverrides,
+  TestClient,
+};


### PR DESCRIPTION
## Summary
- add shared request security helpers reused across API E2E suites
- cover the admin issuance happy path end-to-end including balance and conservation checks
- delegate ledger issuance endpoints to the in-memory bank and expose the validator roster

## Testing
- pnpm --filter @qzd/api test

------
https://chatgpt.com/codex/tasks/task_e_68dd8c34f2488330a181685d3364e9c2