### PR TITLE
Add wallet Playwright smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ packages/sdk-api/src/server/generated
 coverage
 .husky/_
 .env
+test-results

--- a/package.json
+++ b/package.json
@@ -29,13 +29,15 @@
     "docs:dev": "vitepress dev docs --port 5170",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs --port 8088",
-    "docs:check:links": "node scripts/check-doc-links.mjs"
+    "docs:check:links": "node scripts/check-doc-links.mjs",
+    "test:wallet:smoke": "pnpm exec playwright test --config=playwright.wallet.config.ts"
   },
   "devDependencies": {
     "@algolia/client-search": "^5.39.0",
     "@eslint/js": "^9.36.0",
     "@noble/curves": "^1.6.0",
     "@openapitools/openapi-generator-cli": "^2.23.4",
+    "@playwright/test": "^1.55.1",
     "@redocly/cli": "^2.2.1",
     "@stoplight/prism-cli": "^5.14.2",
     "ajv": "^8",

--- a/playwright.wallet.config.ts
+++ b/playwright.wallet.config.ts
@@ -1,0 +1,63 @@
+import { defineConfig, devices } from '@playwright/test';
+import { DEFAULT_REQUEST_SIGNING_PUBLIC_KEY_HEX } from './packages/shared/src/request-security.ts';
+
+const isCI = Boolean(process.env.CI);
+const apiBase = process.env.PLAYWRIGHT_API_BASE_URL ?? 'http://127.0.0.1:3000';
+const walletBase = process.env.PLAYWRIGHT_WALLET_BASE_URL ?? 'http://127.0.0.1:5173';
+const normalizedApiBase = apiBase.replace(/\/$/, '');
+const normalizedWalletBase = walletBase.replace(/\/$/, '');
+const walletUrl = new URL(normalizedWalletBase);
+const walletPort = walletUrl.port || '5173';
+
+export default defineConfig({
+  testDir: './tests/ui',
+  fullyParallel: false,
+  timeout: 120_000,
+  expect: {
+    timeout: 10_000,
+  },
+  reporter: isCI
+    ? [['list'], ['github']]
+    : [['list']],
+  use: {
+    baseURL: normalizedWalletBase,
+    headless: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: [
+    {
+      command: 'pnpm --filter @qzd/api dev',
+      url: `${normalizedApiBase}/health/ready`,
+      reuseExistingServer: !isCI,
+      timeout: 120_000,
+      env: {
+        ...process.env,
+        NODE_ENV: 'test',
+        CORS_ORIGIN: normalizedWalletBase,
+        QZD_REQUEST_SIGNING_PUBLIC_KEY: DEFAULT_REQUEST_SIGNING_PUBLIC_KEY_HEX,
+      },
+    },
+    {
+      command: `pnpm --filter @qzd/wallet-web dev -- --host ${walletUrl.hostname} --port ${walletPort} --strictPort`,
+      url: normalizedWalletBase,
+      reuseExistingServer: !isCI,
+      timeout: 120_000,
+      env: {
+        ...process.env,
+        NODE_ENV: 'test',
+        VITE_API_BASE_URL: normalizedApiBase,
+      },
+    },
+  ],
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: normalizedWalletBase,
+      },
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@openapitools/openapi-generator-cli':
         specifier: ^2.23.4
         version: 2.23.4
+      '@playwright/test':
+        specifier: ^1.55.1
+        version: 1.55.1
       '@redocly/cli':
         specifier: ^2.2.1
         version: 2.2.1(@opentelemetry/api@1.9.0)(ajv@8.17.1)(core-js@3.45.1)
@@ -3319,6 +3322,14 @@ packages:
     dev: true
     optional: true
 
+  /@playwright/test@1.55.1:
+    resolution: {integrity: sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright: 1.55.1
+    dev: true
+
   /@protobufjs/aspromise@1.1.2:
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -6459,6 +6470,14 @@ packages:
       universalify: 2.0.1
     dev: true
 
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -8397,6 +8416,22 @@ packages:
       confbox: 0.1.8
       mlly: 1.8.0
       pathe: 2.0.3
+    dev: true
+
+  /playwright-core@1.55.1:
+    resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dev: true
+
+  /playwright@1.55.1:
+    resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.55.1
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /pluralize@8.0.0:

--- a/tests/ui/wallet-smoke.spec.ts
+++ b/tests/ui/wallet-smoke.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from '@playwright/test';
+import {
+  applyMutationSecurityHeaders,
+  createMutationSecurityHeaders,
+} from '../../packages/shared/src/request-security.ts';
+
+const apiBase = process.env.PLAYWRIGHT_API_BASE_URL ?? 'http://127.0.0.1:3000';
+const normalizedApiBase = apiBase.replace(/\/$/, '');
+
+const signedMethods = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+type RegisterResponse = {
+  account?: { id?: string | null } | null;
+  token?: string | null;
+};
+
+type RegisteredUser = {
+  email: string;
+  password: string;
+  accountId: string;
+};
+
+async function signedJsonFetch<TResponse>(
+  path: string,
+  options: { method?: string; body?: unknown } = {},
+): Promise<TResponse> {
+  const method = (options.method ?? 'GET').toUpperCase();
+  const url = new URL(path, normalizedApiBase);
+  const headers = new Headers({ Accept: 'application/json' });
+  let bodyText: string | undefined;
+
+  if (options.body !== undefined) {
+    bodyText = JSON.stringify(options.body);
+    headers.set('Content-Type', 'application/json');
+  }
+
+  if (signedMethods.has(method)) {
+    const securityHeaders = createMutationSecurityHeaders(
+      method,
+      `${url.pathname}${url.search}`,
+      options.body ?? null,
+    );
+    applyMutationSecurityHeaders(headers, securityHeaders);
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: bodyText,
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(
+      `Request failed: ${method} ${url.toString()} → ${response.status} ${response.statusText} — ${errorBody}`,
+    );
+  }
+
+  const raw = await response.text();
+  return raw ? (JSON.parse(raw) as TResponse) : (undefined as TResponse);
+}
+
+async function registerUser(prefix: string): Promise<RegisteredUser> {
+  const unique = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const email = `${prefix}-${unique}@example.com`;
+  const password = `Pw-${unique}`;
+  const fullName = `${prefix.replace(/[-_]+/g, ' ')} Smoke`;
+
+  const payload = await signedJsonFetch<RegisterResponse>('/auth/register', {
+    method: 'POST',
+    body: { email, password, fullName },
+  });
+
+  const accountId = payload.account?.id;
+  if (!accountId) {
+    throw new Error('Registration response did not include an account id');
+  }
+
+  return { email, password, accountId };
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test('wallet happy path smoke test', async ({ page }) => {
+  const [primary, recipient] = await Promise.all([
+    registerUser('wallet-primary'),
+    registerUser('wallet-recipient'),
+  ]);
+
+  await page.goto('/');
+
+  const loginPanel = page.getByRole('heading', { level: 3, name: 'Log in' }).locator('..');
+  await expect(loginPanel).toBeVisible();
+  await loginPanel.getByLabel('Email').fill(primary.email);
+  await loginPanel.getByLabel('Password').fill(primary.password);
+  await loginPanel.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page.getByText('Logged in successfully.')).toBeVisible();
+
+  await expect(page.getByRole('button', { name: 'Load account' })).toBeVisible();
+  await page.getByLabel('Account ID').fill(primary.accountId);
+  await page.getByRole('button', { name: 'Load account' }).click();
+
+  const balanceRegion = page.getByRole('region', { name: 'Balance' });
+  await expect(balanceRegion.getByRole('definition').first()).toHaveText('1000.00 QZD');
+  await expect(
+    page.getByRole('region', { name: 'Transactions' }).getByText('No transactions to display.'),
+  ).toBeVisible();
+
+  const transferRegion = page.getByRole('region', { name: 'Send transfer' });
+  const transferAmount = '0.25';
+  await transferRegion.getByLabel('Destination account').fill(recipient.accountId);
+  await transferRegion.getByLabel('Amount').fill(transferAmount);
+  await transferRegion.getByLabel('Memo').fill('UI smoke transfer');
+  await transferRegion.getByRole('button', { name: 'Send' }).click();
+
+  const expectedBalance = (1000 - Number(transferAmount)).toFixed(2);
+  await expect(balanceRegion.getByRole('definition').first()).toHaveText(`${expectedBalance} QZD`);
+  await expect(balanceRegion.getByRole('definition').nth(1)).toHaveText(`${expectedBalance} QZD`);
+
+  const transactionsRegion = page.getByRole('region', { name: 'Transactions' });
+  await expect(transactionsRegion.getByText('No transactions to display.')).not.toBeVisible();
+
+  const latestTransaction = transactionsRegion.getByRole('listitem').first();
+  await expect(latestTransaction).toContainText('transfer');
+  await expect(latestTransaction).toContainText(`${transferAmount} QZD`);
+  await expect(latestTransaction).toContainText(`Counterparty: ${recipient.accountId}`);
+});

--- a/tsconfig.playwright.json
+++ b/tsconfig.playwright.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node", "@playwright/test"],
+    "noEmit": true
+  },
+  "include": [
+    "playwright.wallet.config.ts",
+    "tests/ui/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Playwright smoke test that signs in, loads an account, sends a transfer, and verifies the resulting activity
- introduce a dedicated Playwright config and tsconfig plus a workspace script for running the smoke suite
- ignore Playwright artefacts in git so CI only captures failure traces

## Testing
- pnpm test:wallet:smoke

------
https://chatgpt.com/codex/tasks/task_e_68ddb9dae2a0833097bafa8648d1b7f7