### PR TITLE
docs(site): add goals & gap analysis to sidebar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,6 +6,7 @@ const sidebar: DefaultTheme.Sidebar = [
     items: [
       { text: 'Introduction', link: '/' },
       { text: 'Architecture', link: '/architecture' },
+      { text: 'Goals & Gap Analysis', link: '/qzd-goals-and-gap-analysis' },
       { text: 'Deployment (Single Server)', link: '/deployment-single-server' },
       { text: 'Operations Runbook', link: '/runbook' },
     ],


### PR DESCRIPTION
## Summary
- add the Goals & Gap Analysis document to the Overview section of the VitePress sidebar

## Testing
- pnpm -r lint
- pnpm -r typecheck

------
https://chatgpt.com/codex/tasks/task_e_68df18b54fa083308d3546d6cb51615e