### PR TITLE
fix: stabilize wallet pending button states

### DIFF
--- a/apps/wallet-web/src/App.tsx
+++ b/apps/wallet-web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { FormEvent, ReactNode } from 'react';
+import { flushSync } from 'react-dom';
 import {
   AccountsApi,
   AuthApi,
@@ -368,7 +369,9 @@ export default function App() {
         return;
       }
 
-      setTransferStatus('pending');
+      flushSync(() => {
+        setTransferStatus('pending');
+      });
       try {
         await transactionsApi.initiateTransfer({
           idempotencyKey: createIdempotencyKey(),
@@ -416,7 +419,9 @@ export default function App() {
         return;
       }
 
-      setQuoteStatus('pending');
+      flushSync(() => {
+        setQuoteStatus('pending');
+      });
       try {
         const response = await remittancesApi.simulateQuote({ usdAmount: amount, scenario: quoteScenario });
         setQuote(response);


### PR DESCRIPTION
## Summary
- flush wallet transfer and quote state updates synchronously so the buttons disable immediately on submit
- keep the send transfer and preview quote flows keyboard-friendly while requests finish

## Testing
- pnpm test:wallet:smoke --reporter=list

------
https://chatgpt.com/codex/tasks/task_e_68dff8d5b5b08330bd90cda1d9758335